### PR TITLE
:lipstick: 투표하기 전 투표 배치를 5:5로 보이게 변경

### DIFF
--- a/Sources/Present/Common/VoteView/View/VoteView.swift
+++ b/Sources/Present/Common/VoteView/View/VoteView.swift
@@ -201,7 +201,7 @@ final class VoteView: UIView {
             $0.leading.equalToSuperview()
             $0.top.equalTo(firstVoteTitleLabel.snp.bottom).offset(10)
             $0.bottom.equalToSuperview()
-            $0.width.equalTo(UIScreen.main.bounds.width / 2)
+            $0.width.equalTo(UIScreen.main.bounds.width / 2 - 25)
             $0.height.equalTo(100)
         }
         
@@ -209,7 +209,7 @@ final class VoteView: UIView {
             $0.trailing.equalToSuperview()
             $0.top.equalTo(secondVoteTitleLabel.snp.bottom).offset(10)
             $0.bottom.equalToSuperview()
-            $0.width.equalTo(UIScreen.main.bounds.width / 2)
+            $0.width.equalTo(UIScreen.main.bounds.width / 2 - 25)
             $0.height.equalTo(100)
         }
         
@@ -224,12 +224,12 @@ final class VoteView: UIView {
         }
         
         firstVotingCountLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(12)
+            $0.leading.equalToSuperview().inset(10)
             $0.bottom.equalToSuperview().inset(11)
         }
         
         secondVotingCountLabel.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(12)
+            $0.trailing.equalToSuperview().inset(10)
             $0.bottom.equalToSuperview().inset(11)
         }
         


### PR DESCRIPTION
## 제목
제곧내

## 작업 내용
기존 투표버튼의 비율은 시각적으로 봤을 때 확실하게 5:5 가 아니었지만,
현재는 정확하지는 않지만 시각적으로 5:5 비율로 보일 수 있도록 변경하였습니다.
<img src="https://user-images.githubusercontent.com/81687906/209914214-f32b6de0-cc83-416b-a0cf-f22b1388d7c7.png" width="200">
