### PR TITLE
게시물 생성 - 내용입력 조건 추가

### DIFF
--- a/Sources/Network/JwtRequestInterceptor.swift
+++ b/Sources/Network/JwtRequestInterceptor.swift
@@ -22,7 +22,7 @@ final class JwtRequestInterceptor: RequestInterceptor {
         }
         
         let url = APIConstants.reissueURL
-        let headers: HTTPHeaders = ["RefreshToken" : tk.read(key: "refreshToken") ?? .init()]
+        let headers: HTTPHeaders = ["RefreshToken" : tk.read(key: "refreshToken")!]
         
         AF.request(url, method: .patch, encoding: JSONEncoding.default, headers: headers).responseData { [weak self] response in
             print("retry status code = \(response.response?.statusCode)")

--- a/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
+++ b/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
@@ -2,8 +2,11 @@ import UIKit
 import PhotosUI
 import Alamofire
 import RxSwift
+import RxCocoa
 
 final class AddPostViewController: BaseVC<AddPostViewModel> {
+    private let disposeBag = DisposeBag()
+    
     private let scrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
     }
@@ -78,7 +81,7 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     }
     
     private lazy var firstSetTopicButton = UIButton().then {
-        $0.setTitle("주제1", for: .normal)
+        $0.setTitle("주제1 ✏️", for: .normal)
         $0.tag = 0
         $0.setTitleColor(.gray, for: .normal)
         $0.layer.borderWidth = 1
@@ -88,7 +91,7 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     }
     
     private lazy var secondSetTopicButton = UIButton().then {
-        $0.setTitle("주제2", for: .normal)
+        $0.setTitle("주제2 ✏️", for: .normal)
         $0.tag = 1
         $0.setTitleColor(.gray, for: .normal)
         $0.layer.borderWidth = 1
@@ -98,11 +101,23 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     }
     
     private lazy var addPostViewButton = UIButton().then {
-        $0.setTitle("계속", for: .normal)
+        $0.setTitle("완료", for: .normal)
         $0.setTitleColor( .white, for: .normal)
         $0.backgroundColor = ChoiceAsset.Colors.grayMedium.color
         $0.layer.cornerRadius = 8
+        $0.isEnabled = false
         $0.addTarget(self, action: #selector(addPostViewButtonDidTap(_:)), for: .touchUpInside)
+    }
+    
+    private func bindUI() {
+//        Observable.combineLatest(
+//            inputTitleTextField.rx.text.filter { $0 != nil },
+//            inputDescriptionTextView.rx.text.filter { $0 != nil },
+//            firstSetTopicButton.rx.tap
+//        )
+//        .subscribe(onNext: { s in
+//            addPostViewButton.isEnabled = s
+//        }).disposed(by: disposeBag)
     }
     
     @objc private func addFirstImageButtonDidTap(_ sender: UIButton) {

--- a/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
+++ b/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
@@ -155,14 +155,20 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     @objc private func addPostViewButtonDidTap(_ sender: UIButton) {
         let alert = UIAlertController(title: "실패", message: "대표사진을 모두 등록해주세요.", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .cancel))
+        
         guard let title = inputTitleTextField.text else { return }
         guard let content = inputDescriptionTextView.text else { return }
         guard let firstImage = addFirstImageButton.imageView?.image else { return present(alert, animated: true) }
         guard let secondImage = addSecondImageButton.imageView?.image else { return present(alert, animated: true) }
         guard let firstVotingOption = firstSetTopicButton.titleLabel?.text else { return }
         guard let secondVotingOtion = secondSetTopicButton.titleLabel?.text else { return }
+        if firstVotingOption.elementsEqual("주제1 ✏️") || secondVotingOtion.elementsEqual("주제2 ✏️") {
+            alert.message = "주제를 입력해주세요."
+            return present(alert, animated: true)
+        }
 
-        viewModel.createPost(title: title, content: content, firstImage: firstImage, secondImage: secondImage, firstVotingOption: firstVotingOption, secondVotingOtion: secondVotingOtion)
+        viewModel.createPost(title: title, content: content, firstImage: firstImage, secondImage: secondImage,
+                             firstVotingOption: firstVotingOption, secondVotingOtion: secondVotingOtion)
     }
     
     override func configureVC() {

--- a/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
+++ b/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
@@ -110,14 +110,17 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     }
     
     private func bindUI() {
+        let titleTextObservable = inputTitleTextField.rx.text.filter { $0!.count < 20 }
+        let descriptionTextObservable = inputDescriptionTextView.rx.text.filter { $0!.count < 100 }
+        
         Observable.combineLatest(
-            inputTitleTextField.rx.text.filter { 16 > ($0?.count ?? 0) && ($0?.count ?? 0) > 2 },
-            inputDescriptionTextView.rx.text.filter { 100 > ($0?.count ?? 0) && ($0?.count ?? 0) > 20 },
-            resultSelector:  { s1, s2 in (s1 != nil) && (s2 != nil) }
+            titleTextObservable,
+            descriptionTextObservable,
+            resultSelector: { s1, s2 in (s1!.count > 2) && (s2!.count > 20) }
         )
         .subscribe(with: self, onNext: { owner, arg in
-            owner.addPostViewButton.isEnabled = true
-            owner.addPostViewButton.backgroundColor = .black
+            owner.addPostViewButton.isEnabled = arg
+            owner.addPostViewButton.backgroundColor = arg ? .black : ChoiceAsset.Colors.grayMedium.color
         }).disposed(by: disposeBag)
     }
     
@@ -166,7 +169,7 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
             alert.message = "주제를 입력해주세요."
             return present(alert, animated: true)
         }
-
+        
         viewModel.createPost(title: title, content: content, firstImage: firstImage, secondImage: secondImage,
                              firstVotingOption: firstVotingOption, secondVotingOtion: secondVotingOtion)
     }
@@ -292,7 +295,7 @@ extension AddPostViewController: UIImagePickerControllerDelegate, UINavigationCo
         } else if let possibleImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
             newImage = possibleImage
         }
-
+        
         switch picker.restorationIdentifier {
         case "first":
             self.addFirstImageButton.setImage(newImage, for: .normal)

--- a/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
+++ b/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
@@ -56,7 +56,7 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     
     private let inputTitleTextField = UITextField().then {
         $0.font = .systemFont(ofSize: 18, weight: .semibold)
-        $0.placeholder = "제목입력"
+        $0.placeholder = "제목입력 (2~16)"
         $0.textColor = .lightGray
         $0.borderStyle = .none
     }
@@ -66,7 +66,7 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     }
     
     private let inputDescriptionTextView = UITextView().then {
-        $0.text = "내용입력"
+        $0.text = "내용입력 (5~100)"
         $0.font = .systemFont(ofSize: 14, weight: .semibold)
         $0.textColor = .lightGray
         $0.layer.cornerRadius = 8
@@ -110,14 +110,15 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     }
     
     private func bindUI() {
-//        Observable.combineLatest(
-//            inputTitleTextField.rx.text.filter { $0 != nil },
-//            inputDescriptionTextView.rx.text.filter { $0 != nil },
-//            firstSetTopicButton.rx.tap
-//        )
-//        .subscribe(onNext: { s in
-//            addPostViewButton.isEnabled = s
-//        }).disposed(by: disposeBag)
+        Observable.combineLatest(
+            inputTitleTextField.rx.text.filter { 100 > ($0?.count ?? 0) && ($0?.count ?? 0) > 2 },
+            inputDescriptionTextView.rx.text.filter { 16 > ($0?.count ?? 0) && ($0?.count ?? 0) > 20 },
+            resultSelector:  { s1, s2 in (s1 != nil) && (s2 != nil) }
+        )
+        .subscribe(with: self, onNext: { owner, arg in
+            owner.addPostViewButton.isEnabled = arg
+            owner.addPostViewButton.backgroundColor = .black
+        }).disposed(by: disposeBag)
     }
     
     @objc private func addFirstImageButtonDidTap(_ sender: UIButton) {
@@ -152,6 +153,7 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     }
     
     @objc private func addPostViewButtonDidTap(_ sender: UIButton) {
+        print("asdf")
         guard let title = inputTitleTextField.text else { return }
         guard let content = inputDescriptionTextView.text else { return }
         guard let firstImage = addFirstImageButton.imageView?.image else { return }
@@ -168,6 +170,8 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
         inputDescriptionTextView.delegate = self
         firstImagePicker.delegate = self
         secondImagePicker.delegate = self
+        
+        bindUI()
     }
     
     override func addView() {
@@ -252,9 +256,9 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
 extension AddPostViewController: UITextViewDelegate {
     private func setTextViewPlaceholder() {
         if inputDescriptionTextView.text.isEmpty {
-            inputDescriptionTextView.text = "내용입력"
+            inputDescriptionTextView.text = "내용입력 (5~100)"
             inputDescriptionTextView.textColor = UIColor.lightGray
-        } else if inputDescriptionTextView.text == "내용입력"{
+        } else if inputDescriptionTextView.text == "내용입력 (5~100)" {
             inputDescriptionTextView.text = ""
             inputDescriptionTextView.textColor = UIColor.black
         }

--- a/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
+++ b/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
@@ -14,7 +14,7 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     private let contentView = UIView()
     
     private let addImageTitleLabel = UILabel().then {
-        $0.text = "대표 사진을 설정해주세요."
+        $0.text = "대표 사진을 설정해주세요. (필수)"
         $0.font = .systemFont(ofSize: 12, weight: .semibold)
     }
     
@@ -75,7 +75,7 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     }
     
     private let topicTitleLabel = UILabel().then {
-        $0.text = "주제를 입력해주세요"
+        $0.text = "주제를 입력해주세요. (필수)"
         $0.font = .systemFont(ofSize: 12, weight: .semibold)
         $0.textColor = .black
     }

--- a/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
+++ b/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
@@ -111,12 +111,12 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     
     private func bindUI() {
         Observable.combineLatest(
-            inputTitleTextField.rx.text.filter { 100 > ($0?.count ?? 0) && ($0?.count ?? 0) > 2 },
-            inputDescriptionTextView.rx.text.filter { 16 > ($0?.count ?? 0) && ($0?.count ?? 0) > 20 },
+            inputTitleTextField.rx.text.filter { 16 > ($0?.count ?? 0) && ($0?.count ?? 0) > 2 },
+            inputDescriptionTextView.rx.text.filter { 100 > ($0?.count ?? 0) && ($0?.count ?? 0) > 20 },
             resultSelector:  { s1, s2 in (s1 != nil) && (s2 != nil) }
         )
         .subscribe(with: self, onNext: { owner, arg in
-            owner.addPostViewButton.isEnabled = arg
+            owner.addPostViewButton.isEnabled = true
             owner.addPostViewButton.backgroundColor = .black
         }).disposed(by: disposeBag)
     }
@@ -153,14 +153,15 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
     }
     
     @objc private func addPostViewButtonDidTap(_ sender: UIButton) {
-        print("asdf")
+        let alert = UIAlertController(title: "실패", message: "대표사진을 모두 등록해주세요.", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .cancel))
         guard let title = inputTitleTextField.text else { return }
         guard let content = inputDescriptionTextView.text else { return }
-        guard let firstImage = addFirstImageButton.imageView?.image else { return }
-        guard let secondImage = addSecondImageButton.imageView?.image else { return }
+        guard let firstImage = addFirstImageButton.imageView?.image else { return present(alert, animated: true) }
+        guard let secondImage = addSecondImageButton.imageView?.image else { return present(alert, animated: true) }
         guard let firstVotingOption = firstSetTopicButton.titleLabel?.text else { return }
         guard let secondVotingOtion = secondSetTopicButton.titleLabel?.text else { return }
-        
+
         viewModel.createPost(title: title, content: content, firstImage: firstImage, secondImage: secondImage, firstVotingOption: firstVotingOption, secondVotingOtion: secondVotingOtion)
     }
     


### PR DESCRIPTION
## 제목
게시물 생성 페이지에서 필수내용 입력 조건을 추가했습니다.

## 작업 내용
1. 이미지 선택 유무 판단
2. 주제 입력 유무 판단
3. 제목과 설명 입력 유무 판단
     - 길이 조건: 제목 - (2 ~ 6), 설명 - (20 ~ 100)

**3번 조건 달성시 완료 버튼이 활성화 됩니다.**
<div>
<img src="https://user-images.githubusercontent.com/81687906/224234558-92405927-f23b-4068-9a90-89be93326eb7.png" width="200">
<img src="https://user-images.githubusercontent.com/81687906/224233716-a628ee23-6a67-4df7-b54a-ac60d8be0ddc.png" width="200">
</div>

**1, 2번에서 실패 시 alert로 실패 메세지를 띄웁니다.**
<div>
<img src="https://user-images.githubusercontent.com/81687906/224233983-0247c2fc-f4d3-4a07-a4dd-7e2fac96300d.png" width="200">
<img src="https://user-images.githubusercontent.com/81687906/224233989-fc0c3cb4-e78d-457a-bd6f-924d979366a2.png" width="200">
</div>