### PR TITLE
:recycle: LoadingIndicator warning 해결

### DIFF
--- a/Sources/Util/Class/LoadingIndicator.swift
+++ b/Sources/Util/Class/LoadingIndicator.swift
@@ -4,7 +4,7 @@ final class LoadingIndicator {
     private init() {}
     static func showLoading() {
         DispatchQueue.main.async {
-            guard let window = UIApplication.shared.windows.last else { return }
+            guard let window = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.last else { return }
             let loadingIndicatorView: UIActivityIndicatorView
             let loadingLabel = UILabel()
             if let existedView = window.subviews.first(where: { $0 is UIActivityIndicatorView } ) as? UIActivityIndicatorView {
@@ -23,7 +23,7 @@ final class LoadingIndicator {
 
     static func hideLoading() {
         DispatchQueue.main.async {
-            guard let window = UIApplication.shared.windows.last else { return }
+            guard let window = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.last else { return }
             window.subviews.filter({ $0 is UIActivityIndicatorView }).forEach { $0.removeFromSuperview() }
             window.subviews.filter({ $0 is UILabel }).forEach { $0.removeFromSuperview() }
         }


### PR DESCRIPTION
## 제목
제곧내

## 작업 내용
iOS 15.0 버전부턴 deprecated 하기 때문에 생긴 warning을 해결했습니다.