### PR TITLE
UserSecurityInfoVC SignUpButton 상태 제어 / 회원가입 UI 수정

### DIFF
--- a/Sources/Network/APIConstants.swift
+++ b/Sources/Network/APIConstants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct APIConstants {
-    static let baseURL = "https://port-0-choice-backend-p8xrq2mlfhw9efx.sel3.cloudtype.app/8080"
+    static let baseURL = "http://10.82.17.76:81"
     
     //SignIn
     static let signInURL = baseURL + "/auth/signin"

--- a/Sources/Network/APIConstants.swift
+++ b/Sources/Network/APIConstants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct APIConstants {
-    static let baseURL = "http://10.82.17.76:81"
+    static let baseURL = "https://port-0-choice-backend-p8xrq2mlfhw9efx.sel3.cloudtype.app/8080"
     
     //SignIn
     static let signInURL = baseURL + "/auth/signin"

--- a/Sources/Present/Auth/SignUp/UserProfileInfo/ViewController/UserProfileInfoViewController.swift
+++ b/Sources/Present/Auth/SignUp/UserProfileInfo/ViewController/UserProfileInfoViewController.swift
@@ -11,7 +11,7 @@ final class UserProfileInfoViewController: BaseVC<UserProfileInfoViewModel> {
     private let profileImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFill
         $0.clipsToBounds = true
-        $0.layer.cornerRadius = 50
+        $0.layer.cornerRadius = 70
         $0.image = UIImage(systemName: "person.crop.circle.fill")
         $0.tintColor = .black
     }
@@ -28,10 +28,14 @@ final class UserProfileInfoViewController: BaseVC<UserProfileInfoViewModel> {
     
     private let imagePickerController = UIImagePickerController()
     
-    private let userNameTextField = UnderLineTextField().then {
-        $0.setPlaceholder(placeholder: "닉네임")
+    private let userNameTextField = UITextField().then {
+        $0.placeholder = "닉네임을 입력해 주세요"
         $0.textAlignment = .center
         $0.font = .systemFont(ofSize: 14, weight: .semibold)
+    }
+    
+    private let underLineView = UIView().then {
+        $0.backgroundColor = .gray
     }
     
     private let warningLabel = UILabel().then {
@@ -62,7 +66,7 @@ final class UserProfileInfoViewController: BaseVC<UserProfileInfoViewModel> {
             .bind(with: self, onNext: { owner, isValid  in
                 if isValid {
                     owner.warningLabel.textColor = .red
-                    owner.warningLabel.text = "*2자 이상 6자 이하로 입력 해주세요."
+                    owner.warningLabel.text = "*2자 이상 6자 이하로 입력해 주세요."
                     
                     owner.completeButton.isEnabled = false
                     owner.completeButton.backgroundColor = ChoiceAsset.Colors.grayDark.color
@@ -123,7 +127,7 @@ final class UserProfileInfoViewController: BaseVC<UserProfileInfoViewModel> {
     
     override func addView() {
         view.addSubviews(profileImageView, setProfileImageButton,
-                         userNameTextField, warningLabel, completeButton)
+                         userNameTextField, underLineView, warningLabel, completeButton)
     }
     
     override func setLayout() {
@@ -140,7 +144,15 @@ final class UserProfileInfoViewController: BaseVC<UserProfileInfoViewModel> {
         
         userNameTextField.snp.makeConstraints {
             $0.top.equalTo(profileImageView.snp.bottom).offset(80)
-            $0.leading.trailing.equalToSuperview().inset(100)
+            $0.centerX.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(93)
+        }
+        
+        underLineView.snp.makeConstraints {
+            $0.top.equalTo(userNameTextField.snp.bottom).offset(10)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(1)
+            $0.leading.trailing.equalToSuperview().inset(93)
         }
         
         warningLabel.snp.makeConstraints {

--- a/Sources/Present/Auth/SignUp/UserProfileInfo/ViewController/UserProfileInfoViewController.swift
+++ b/Sources/Present/Auth/SignUp/UserProfileInfo/ViewController/UserProfileInfoViewController.swift
@@ -28,14 +28,10 @@ final class UserProfileInfoViewController: BaseVC<UserProfileInfoViewModel> {
     
     private let imagePickerController = UIImagePickerController()
     
-    private let userNameTextField = UITextField().then {
-        $0.placeholder = "닉네임을 입력해 주세요"
+    private let userNameTextField = UnderLineTextField().then {
+        $0.setPlaceholder(placeholder: "닉네임을 입력해 주세요")
         $0.textAlignment = .center
         $0.font = .systemFont(ofSize: 14, weight: .semibold)
-    }
-    
-    private let underLineView = UIView().then {
-        $0.backgroundColor = .gray
     }
     
     private let warningLabel = UILabel().then {
@@ -127,7 +123,7 @@ final class UserProfileInfoViewController: BaseVC<UserProfileInfoViewModel> {
     
     override func addView() {
         view.addSubviews(profileImageView, setProfileImageButton,
-                         userNameTextField, underLineView, warningLabel, completeButton)
+                         userNameTextField, warningLabel, completeButton)
     }
     
     override func setLayout() {
@@ -145,13 +141,6 @@ final class UserProfileInfoViewController: BaseVC<UserProfileInfoViewModel> {
         userNameTextField.snp.makeConstraints {
             $0.top.equalTo(profileImageView.snp.bottom).offset(80)
             $0.centerX.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(93)
-        }
-        
-        underLineView.snp.makeConstraints {
-            $0.top.equalTo(userNameTextField.snp.bottom).offset(10)
-            $0.centerX.equalToSuperview()
-            $0.height.equalTo(1)
             $0.leading.trailing.equalToSuperview().inset(93)
         }
         

--- a/Sources/Present/Auth/SignUp/UserSecurityInfo/ViewController/UserSecurityInfoViewController.swift
+++ b/Sources/Present/Auth/SignUp/UserSecurityInfo/ViewController/UserSecurityInfoViewController.swift
@@ -58,13 +58,8 @@ final class UserSecurityInfoViewController: BaseVC<UserSecurityInfoViewModel> {
             resultSelector: { s1, s2, s3 in (s1.count > 0) && (s2.count > 0) && (s3.count > 0) }
         )
         .bind(with: self, onNext: { owner, isValid in
-            if isValid {
-                owner.signUpButton.isEnabled = true
-                owner.signUpButton.backgroundColor = .black
-            } else {
-                owner.signUpButton.isEnabled = false
-                owner.signUpButton.backgroundColor = ChoiceAsset.Colors.grayDark.color
-            }
+            owner.signUpButton.isEnabled = isValid
+            owner.signUpButton.backgroundColor = isValid ? .black : ChoiceAsset.Colors.grayDark.color
         })
         .disposed(by: disposeBag)
     }

--- a/Sources/Present/Auth/SignUp/UserSecurityInfo/ViewController/UserSecurityInfoViewController.swift
+++ b/Sources/Present/Auth/SignUp/UserSecurityInfo/ViewController/UserSecurityInfoViewController.swift
@@ -35,8 +35,8 @@ final class UserSecurityInfoViewController: BaseVC<UserSecurityInfoViewModel> {
     
     private lazy var signUpButton = UIButton().then {
         $0.setTitle("다음", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .black
+        $0.isEnabled = false
+        $0.backgroundColor = ChoiceAsset.Colors.grayDark.color
         $0.layer.cornerRadius = 8
     }
     
@@ -44,6 +44,29 @@ final class UserSecurityInfoViewController: BaseVC<UserSecurityInfoViewModel> {
         $0.font = .systemFont(ofSize: 14)
         $0.isHidden = true
         $0.textColor = .init(red: 1, green: 0.363, blue: 0.363, alpha: 1)
+    }
+    
+    private func bindUI() {
+        let titleTextObservable = inputEmailTextfield.rx.text.orEmpty
+        let descriptionTextObservable = inputPasswordTextfield.rx.text.orEmpty
+        let checkPasswordTestObservable = inputCheckPasswordTextfield.rx.text.orEmpty
+
+        Observable.combineLatest(
+            titleTextObservable,
+            descriptionTextObservable,
+            checkPasswordTestObservable,
+            resultSelector: { s1, s2, s3 in (s1.count > 0) && (s2.count > 0) && (s3.count > 0) }
+        )
+        .bind(with: self, onNext: { owner, isValid in
+            if isValid {
+                owner.signUpButton.isEnabled = true
+                owner.signUpButton.backgroundColor = .black
+            } else {
+                owner.signUpButton.isEnabled = false
+                owner.signUpButton.backgroundColor = ChoiceAsset.Colors.grayDark.color
+            }
+        })
+        .disposed(by: disposeBag)
     }
     
     private func shakeAllTextField() {
@@ -105,6 +128,8 @@ final class UserSecurityInfoViewController: BaseVC<UserSecurityInfoViewModel> {
     override func configureVC() {
         restoreFrameYValue = self.view.frame.origin.y
         signUpButtonDidTap()
+        
+        bindUI()
         
         navigationItem.title = "회원가입"
     }

--- a/Sources/Util/Class/UnderLineTextField.swift
+++ b/Sources/Util/Class/UnderLineTextField.swift
@@ -23,7 +23,7 @@ final class UnderLineTextField: UITextField {
     
     func setPlaceholder(placeholder: String) {
         self.font = .systemFont(ofSize: 14)
-        self.leftView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 5.0, height: 0.0))
+        self.leftView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 2.0, height: 0.0))
         self.leftViewMode = .always
         self.attributedPlaceholder = NSAttributedString(
             string: placeholder,


### PR DESCRIPTION
## 제목
UserSecurityInfoVC SignUpButton 상태 제어
회원가입 UI 수정
## 작업 내용
- UserSecurityInfoVC 내용 여부에 따라 버튼 상태 제어 
- UserProfileInfoVC 를 살짝 수정했습니다
<img src = "https://user-images.githubusercontent.com/80827042/229468900-13591282-b182-43eb-8253-e2ad1c4aca91.png" width = 300 />
<img src = "https://user-images.githubusercontent.com/80827042/229469519-9809029b-94ef-4706-a886-e99ae7521086.png" width = 300 />


