### PR TITLE
댓글 삭제 기능 구현

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -12,7 +12,8 @@ let project = Project(
         .Kingfisher,
         .RxSwift,
         .RxCocoa,
-        .Alamofire
+        .Alamofire,
+        .RxDataSources
     ],
     targets: [
         Target(
@@ -30,7 +31,8 @@ let project = Project(
                 .SPM.Kingfisher,
                 .SPM.RxSwift,
                 .SPM.RxCocoa,
-                .SPM.Alamofire
+                .SPM.Alamofire,
+                .SPM.RxDataSources
             ]
         )
     ]

--- a/Project.swift
+++ b/Project.swift
@@ -12,8 +12,7 @@ let project = Project(
         .Kingfisher,
         .RxSwift,
         .RxCocoa,
-        .Alamofire,
-        .RxDataSources
+        .Alamofire
     ],
     targets: [
         Target(
@@ -31,8 +30,7 @@ let project = Project(
                 .SPM.Kingfisher,
                 .SPM.RxSwift,
                 .SPM.RxCocoa,
-                .SPM.Alamofire,
-                .SPM.RxDataSources
+                .SPM.Alamofire
             ]
         )
     ]

--- a/Project.swift
+++ b/Project.swift
@@ -35,7 +35,3 @@ let project = Project(
         )
     ]
 )
-
-let baseSettings: [String: SettingValue] = [
-    "Preprocessor_Macros" : "FLEXLAYOUT_SWIFT_PACKAGE=1"
-]

--- a/Sources/Network/APIConstants.swift
+++ b/Sources/Network/APIConstants.swift
@@ -27,7 +27,7 @@ struct APIConstants {
     //Comment
     static let createCommentURL = baseURL + "/comment/"
     static let editCommentURL = baseURL + "/comment"
-    static let deleteCommentURL = baseURL + "/comment"
+    static let deleteCommentURL = baseURL + "/comment/"
     
     //Profile
     static let profileURL = baseURL + "/user"

--- a/Sources/Present/Common/Cell/PostCell/PostCell.swift
+++ b/Sources/Present/Common/Cell/PostCell/PostCell.swift
@@ -13,8 +13,7 @@ protocol PostVoteButtonDidTapDelegate: AnyObject {
     func postVoteButtonDidTap(idx: Int, choice: Int)
 }
 
-final class PostCell: UITableViewCell{
-    let vm = HomeViewModel(coordinator: .init(navigationController: UINavigationController()))
+final class PostCell: UITableViewCell {
     var model: PostModel?
     var delegate: PostTableViewCellButtonDelegate?
     var postVoteButtonDelegate: PostVoteButtonDidTapDelegate?

--- a/Sources/Present/Detail/Cell/CommentCell.swift
+++ b/Sources/Present/Detail/Cell/CommentCell.swift
@@ -2,14 +2,8 @@ import UIKit
 import Then
 import SnapKit
 
-protocol CommentFuncProtocol: AnyObject {
-    func deleteComment(commentIdx: Int)
-}
-
 final class CommentCell: UITableViewCell {
     static let identifier = "CommentCellIdentifier"
-    
-    weak var delegate: CommentFuncProtocol?
 
     private let profileImageView = UIImageView().then {
         $0.tintColor = .black

--- a/Sources/Present/Detail/Model/CommentModel.swift
+++ b/Sources/Present/Detail/Model/CommentModel.swift
@@ -11,4 +11,5 @@ struct CommentData: Codable {
     var nickname: String
     var content: String
     var image: String
+    var isMine: Bool
 }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -127,28 +127,28 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             cell.changeCommentData(model: data)
         }.disposed(by: disposeBag)
         
-//        commentTableView.rx.modelDeleted(CommentData.self)
-//            .bind(with: self, onNext: { owner, arg in
-//                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) { result in
-//                    switch result {
-//                    case .success(()):
-//                        owner.viewModel.callToCommentData(idx: owner.model!.idx)
-//                        owner.commentTableView.reloadRows(
-//                            at: [IndexPath(row: arg.idx, section: 0)],
-//                            with: .automatic
-//                        )
-//                    case .failure(let error):
-//                        print("Delete Comment Error - \(error.localizedDescription)")
-//                        let sheet = UIAlertController(
-//                            title: "실패",
-//                            message: "자신이 작성한 댓글만 삭제할 수 있습니다.",
-//                            preferredStyle: .alert
-//                        )
-//                        sheet.addAction(UIAlertAction(title: "확인", style: .cancel))
-//                        owner.present(sheet, animated: true)
-//                    }
-//                }
-//            }).disposed(by: disposeBag)
+        commentTableView.rx.modelDeleted(CommentData.self)
+            .bind(with: self, onNext: { owner, arg in
+                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) { result in
+                    switch result {
+                    case .success(()):
+                        owner.viewModel.callToCommentData(idx: owner.model!.idx)
+                        owner.commentTableView.reloadRows(
+                            at: [IndexPath(row: arg.idx, section: 0)],
+                            with: .automatic
+                        )
+                    case .failure(let error):
+                        print("Delete Comment Error - \(error.localizedDescription)")
+                        let sheet = UIAlertController(  
+                            title: "실패",
+                            message: "자신이 작성한 댓글만 삭제할 수 있습니다.",
+                            preferredStyle: .alert
+                        )
+                        sheet.addAction(UIAlertAction(title: "확인", style: .cancel))
+                        owner.present(sheet, animated: true)
+                    }
+                }
+            }).disposed(by: disposeBag)
     }
     
     private func bindUI() {
@@ -179,15 +179,16 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         enterCommentButton.rx.tap
             .bind(with: self, onNext: { owner, _ in
                 owner.enterComment()
-                owner.callToCommentData()
+//                owner.callToCommentData()
+                owner.viewModel.callToCommentData(idx: owner.model!.idx)
             }).disposed(by: disposeBag)
     }
     
-    private func callToCommentData() {
-        guard let idx = model?.idx else { return }
-        
-        viewModel.callToCommentData(idx: idx)
-    }
+//    private func callToCommentData() {
+//        guard let idx = model?.idx else { return }
+//
+//        viewModel.callToCommentData(idx: idx)
+//    }
     
     private func changePostData(model: PostModel) {
         guard let firstImageUrl = URL(string: model.firstImageUrl) else { return }
@@ -248,7 +249,8 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.commentTableView.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)
-        callToCommentData()
+//        callToCommentData()
+        viewModel.callToCommentData(idx: model!.idx)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -422,34 +424,7 @@ extension DetailPostViewController: UITextViewDelegate {
 
 extension DetailPostViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        print("asdfsafasd")
-        self.commentTableView.rx.modelDeleted(CommentData.self)
-            .bind(with: self, onNext: { owner, arg in
-                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) { result in
-//                    return result ? configuration : configuration
-//                    switch result {
-//                    case .success(()):
-//                        owner.viewModel.callToCommentData(idx: owner.model!.idx)
-//                        owner.commentTableView.reloadRows(
-//                            at: [IndexPath(row: arg.idx, section: 0)],
-//                            with: .automatic
-//                        )
-//                        configuration = UISwipeActionsConfiguration(actions: [UIContextualAction(style: .destructive, title: "삭제", handler: { UIContextual, view, _ in
-//                        })])
-//                    case .failure(let error):
-//                        print("Delete Comment Error - \(error.localizedDescription)")
-//                        let sheet = UIAlertController(
-//                            title: "실패",
-//                            message: "자신이 작성한 댓글만 삭제할 수 있습니다.",
-//                            preferredStyle: .alert
-//                        )
-//                        sheet.addAction(UIAlertAction(title: "확인", style: .cancel))
-//                        owner.present(sheet, animated: true)
-//                        configuration = .none
-//                    }
-                }
-            }).disposed(by: self.disposeBag)
-        return UISwipeActionsConfiguration(actions: [UIContextualAction(style: .destructive, title: "삭제", handler: { UIContextual, view, _ in
+        return UISwipeActionsConfiguration(actions: [UIContextualAction(style: .destructive, title: "hi", handler: { first, second, _ in
         })])
     }
 }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -129,6 +129,10 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                                                        cellType: CommentCell.self)) { (row, data, cell) in
                 cell.changeCommentData(model: data)
         }.disposed(by: disposeBag)
+        
+        commentTableView.rx.itemDeleted.bind(onNext: { _ in
+            
+        })
     }
     
     private func bindUI() {

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -126,27 +126,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                                                        cellType: CommentCell.self)) { (row, data, cell) in
             cell.changeCommentData(model: data)
         }.disposed(by: disposeBag)
-
-        
-//        viewModel.deleteComment(postIdx: model!.idx, commentIdx: 1) { [weak self] result in
-//            switch result {
-//            case .success(()):
-//                self?.viewModel.callToCommentData(idx: (self?.model!.idx)!)
-////                commentTableView.reloadRows(
-////                    at: [IndexPath(row: arg.idx, section: 0)],
-////                    with: .automatic
-////                )
-//            case .failure(let error):
-//                print("Delete Comment Error - \(error.localizedDescription)")
-//                let sheet = UIAlertController(
-//                    title: "실패",
-//                    message: "자신이 작성한 댓글만 삭제할 수 있습니다.",
-//                    preferredStyle: .alert
-//                )
-//                sheet.addAction(UIAlertAction(title: "확인", style: .cancel))
-//                self?.present(sheet, animated: true)
-//            }
-//        }
     }
     
     private func bindUI() {
@@ -240,7 +219,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.commentTableView.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)
-        //        callToCommentData()
         viewModel.callToCommentData(idx: model!.idx)
     }
     

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -128,12 +128,17 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
 
         commentTableView.rx.modelDeleted(CommentData.self)
             .bind(with: self, onNext: { owner, arg in
-                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) {
-                    owner.viewModel.callToCommentData(idx: owner.model!.idx)
-                    owner.commentTableView.reloadRows(at: [IndexPath(row: arg.idx, section: 0)], with: .automatic)
+                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) { result in
+                    
+                    switch result {
+                    case .success(()):
+                        owner.viewModel.callToCommentData(idx: owner.model!.idx)
+                        owner.commentTableView.reloadRows(at: [IndexPath(row: arg.idx, section: 03)], with: .automatic)
+                    case .failure(let error):
+                        print("Delete Comment Error - \(error.localizedDescription)")
+                    }
                 }
             }).disposed(by: disposeBag)
-        
     }
     
     private func bindUI() {

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -125,22 +125,29 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                                                        cellType: CommentCell.self)) { (row, data, cell) in
             cell.changeCommentData(model: data)
         }.disposed(by: disposeBag)
-
-        commentTableView.rx.modelDeleted(CommentData.self)
-            .bind(with: self, onNext: { owner, arg in
-                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) { result in
-                    switch result {
-                    case .success(()):
-                        owner.viewModel.callToCommentData(idx: owner.model!.idx)
-                        owner.commentTableView.reloadRows(
-                            at: [IndexPath(row: arg.idx, section: 0)],
-                            with: .automatic
-                        )
-                    case .failure(let error):
-                        print("Delete Comment Error - \(error.localizedDescription)")
-                    }
-                }
-            }).disposed(by: disposeBag)
+        
+//        commentTableView.rx.modelDeleted(CommentData.self)
+//            .bind(with: self, onNext: { owner, arg in
+//                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) { result in
+//                    switch result {
+//                    case .success(()):
+//                        owner.viewModel.callToCommentData(idx: owner.model!.idx)
+//                        owner.commentTableView.reloadRows(
+//                            at: [IndexPath(row: arg.idx, section: 0)],
+//                            with: .automatic
+//                        )
+//                    case .failure(let error):
+//                        print("Delete Comment Error - \(error.localizedDescription)")
+//                        let sheet = UIAlertController(
+//                            title: "실패",
+//                            message: "자신이 작성한 댓글만 삭제할 수 있습니다.",
+//                            preferredStyle: .alert
+//                        )
+//                        sheet.addAction(UIAlertAction(title: "확인", style: .cancel))
+//                        owner.present(sheet, animated: true)
+//                    }
+//                }
+//            }).disposed(by: disposeBag)
     }
     
     private func bindUI() {

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import RxDataSources
 import Kingfisher
 
 final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataProtocol {
@@ -269,6 +270,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     override func configureVC() {
         enterCommentTextView.delegate = self
         viewModel.delegate = self
+        commentTableView.delegate = self
         
         bindTableView()
         bindUI()
@@ -415,5 +417,39 @@ extension DetailPostViewController: UITextViewDelegate {
         if textView.text == "" {
             setTextViewPlaceholder()
         }
+    }
+}
+
+extension DetailPostViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        print("asdfsafasd")
+        self.commentTableView.rx.modelDeleted(CommentData.self)
+            .bind(with: self, onNext: { owner, arg in
+                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) { result in
+//                    return result ? configuration : configuration
+//                    switch result {
+//                    case .success(()):
+//                        owner.viewModel.callToCommentData(idx: owner.model!.idx)
+//                        owner.commentTableView.reloadRows(
+//                            at: [IndexPath(row: arg.idx, section: 0)],
+//                            with: .automatic
+//                        )
+//                        configuration = UISwipeActionsConfiguration(actions: [UIContextualAction(style: .destructive, title: "삭제", handler: { UIContextual, view, _ in
+//                        })])
+//                    case .failure(let error):
+//                        print("Delete Comment Error - \(error.localizedDescription)")
+//                        let sheet = UIAlertController(
+//                            title: "실패",
+//                            message: "자신이 작성한 댓글만 삭제할 수 있습니다.",
+//                            preferredStyle: .alert
+//                        )
+//                        sheet.addAction(UIAlertAction(title: "확인", style: .cancel))
+//                        owner.present(sheet, animated: true)
+//                        configuration = .none
+//                    }
+                }
+            }).disposed(by: self.disposeBag)
+        return UISwipeActionsConfiguration(actions: [UIContextualAction(style: .destructive, title: "삭제", handler: { UIContextual, view, _ in
+        })])
     }
 }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -401,7 +401,7 @@ extension DetailPostViewController: UITableViewDelegate {
                 case .success(()):
                     self?.viewModel.callToCommentData(idx: self!.model!.idx)
                     self?.commentTableView.reloadRows(
-                    at: [IndexPath(row: commentModel.idx, section: 0)],
+                    at: [indexPath],
                     with: .automatic
                     )
                 case .failure(let error):

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -129,11 +129,13 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         commentTableView.rx.modelDeleted(CommentData.self)
             .bind(with: self, onNext: { owner, arg in
                 owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) { result in
-                    
                     switch result {
                     case .success(()):
                         owner.viewModel.callToCommentData(idx: owner.model!.idx)
-                        owner.commentTableView.reloadRows(at: [IndexPath(row: arg.idx, section: 03)], with: .automatic)
+                        owner.commentTableView.reloadRows(
+                            at: [IndexPath(row: arg.idx, section: 0)],
+                            with: .automatic
+                        )
                     case .failure(let error):
                         print("Delete Comment Error - \(error.localizedDescription)")
                     }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import RxSwift
 import RxCocoa
-import RxDataSources
 import Kingfisher
 
 final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataProtocol {

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -132,9 +132,10 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
 
         commentTableView.rx.modelDeleted(CommentData.self)
             .bind(with: self, onNext: { owner, arg in
-                print("commentData = \(arg.idx)")
-                print("postModel = \(owner.model?.idx)")
-                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx)
+                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx) {
+                    owner.viewModel.callToCommentData(idx: owner.model!.idx)
+                    owner.commentTableView.reloadRows(at: [IndexPath(row: arg.idx, section: 0)], with: .automatic)
+                }
             }).disposed(by: disposeBag)
         
     }
@@ -156,6 +157,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         LoadingIndicator.showLoading()
         viewModel.createComment(idx: idx, content: content) {
             DispatchQueue.main.async {
+                self.viewModel.callToCommentData(idx: idx)
                 self.commentTableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
             }
             LoadingIndicator.hideLoading()

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -127,12 +127,16 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     private func bindTableView() {
         commentData.bind(to: commentTableView.rx.items(cellIdentifier: CommentCell.identifier,
                                                        cellType: CommentCell.self)) { (row, data, cell) in
-                cell.changeCommentData(model: data)
+            cell.changeCommentData(model: data)
         }.disposed(by: disposeBag)
+
+        commentTableView.rx.modelDeleted(CommentData.self)
+            .bind(with: self, onNext: { owner, arg in
+                print("commentData = \(arg.idx)")
+                print("postModel = \(owner.model?.idx)")
+                owner.viewModel.deleteComment(postIdx: owner.model!.idx, commentIdx: arg.idx)
+            }).disposed(by: disposeBag)
         
-        commentTableView.rx.itemDeleted.bind(onNext: { _ in
-            
-        })
     }
     
     private func bindUI() {

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -395,22 +395,24 @@ extension DetailPostViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         var config: UISwipeActionsConfiguration? = nil
         let commentModel = commentData.value[indexPath.row]
-        
+        lazy var contextual = UIContextualAction(style: .destructive, title: nil, handler: { [weak self] _, _, _ in
+            self?.viewModel.deleteComment(postIdx: self!.model!.idx, commentIdx: commentModel.idx, completion: { result in
+                switch result {
+                case .success(()):
+                    self?.viewModel.callToCommentData(idx: self!.model!.idx)
+                    self?.commentTableView.reloadRows(
+                    at: [IndexPath(row: commentModel.idx, section: 0)],
+                    with: .automatic
+                    )
+                case .failure(let error):
+                    print("Delete Faield = \(error.localizedDescription)")
+                }
+            })
+        })
+        contextual.image = UIImage(systemName: "trash")
+
         if commentModel.isMine {
-            config = UISwipeActionsConfiguration(actions: [UIContextualAction(style: .destructive, title: "hi", handler: { [weak self] first, second, _ in
-                self?.viewModel.deleteComment(postIdx: self!.model!.idx, commentIdx: commentModel.idx, completion: { result in
-                    switch result {
-                    case .success(()):
-                        self?.viewModel.callToCommentData(idx: self!.model!.idx)
-                        self?.commentTableView.reloadRows(
-                        at: [IndexPath(row: commentModel.idx, section: 0)],
-                        with: .automatic
-                        )
-                    case .failure(let error):
-                        print("Delete Faield = \(error.localizedDescription)")
-                    }
-                })
-            })])
+            config = UISwipeActionsConfiguration(actions: [contextual])
         }
         return config
     }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -154,7 +154,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         guard let idx = model?.idx else { return }
         guard let content = enterCommentTextView.text else { return }
         
-        LoadingIndicator.showLoading()
+        LoadingIndicator.showLoading(text: "게시 중")
         viewModel.createComment(idx: idx, content: content) {
             DispatchQueue.main.async {
                 self.viewModel.callToCommentData(idx: idx)

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -11,7 +11,7 @@ protocol CommentDataProtocol: AnyObject {
 final class DetailPostViewModel: BaseViewModel {
     weak var delegate: CommentDataProtocol?
     
-    func deleteComment(postIdx: Int, commentIdx: Int) {
+    func deleteComment(postIdx: Int, commentIdx: Int, completion: @escaping () -> ()) {
         print(commentIdx)
         let url = APIConstants.deleteCommentURL + "\(postIdx)/" + "\(commentIdx)"
         AF.request(url,
@@ -19,10 +19,11 @@ final class DetailPostViewModel: BaseViewModel {
                    encoding: URLEncoding.queryString,
                    interceptor: JwtRequestInterceptor())
         .validate()
-        .responseData(emptyResponseCodes: [200, 201, 204]) { response in
+        .responseData(emptyResponseCodes: [200, 201, 204]) { [weak self] response in
             switch response.result {
             case .success:
                 print("success")
+                completion()
             case .failure(let error):
                 print(error)
             }
@@ -64,7 +65,6 @@ final class DetailPostViewModel: BaseViewModel {
         .responseData(emptyResponseCodes: [200, 201, 204]) { response in
             switch response.result {
             case .success:
-                self.callToCommentData(idx: idx)
                 completion()
             case .failure(let error):
                 print("post error = \(String(describing: error.localizedDescription))")

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -25,7 +25,6 @@ final class DetailPostViewModel: BaseViewModel {
                 completion(.success(()))
             case .failure(let error):
                 completion(.failure(error))
-                print(error)
             }
         }
     }

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -11,8 +11,9 @@ protocol CommentDataProtocol: AnyObject {
 final class DetailPostViewModel: BaseViewModel {
     weak var delegate: CommentDataProtocol?
     
-    func deleteComment(commentIdx: Int) {
-        let url = APIConstants.deleteCommentURL + "\(commentIdx)"
+    func deleteComment(postIdx: Int, commentIdx: Int) {
+        print(commentIdx)
+        let url = APIConstants.deleteCommentURL + "\(postIdx)/" + "\(commentIdx)"
         AF.request(url,
                    method: .delete,
                    encoding: URLEncoding.queryString,

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -1,11 +1,12 @@
 import Foundation
 import RxSwift
 import Alamofire
+import RxRelay
 
 protocol CommentDataProtocol: AnyObject {
     var writerNameData: PublishSubject<String> { get set  }
     var writerImageStringData: PublishSubject<String> { get set }
-    var commentData: PublishSubject<[CommentData]> { get set }
+    var commentData: BehaviorRelay<[CommentData]> { get set }
 }
 
 final class DetailPostViewModel: BaseViewModel {
@@ -42,7 +43,7 @@ final class DetailPostViewModel: BaseViewModel {
                 let decodeResponse = try! JSONDecoder().decode(CommentModel.self, from: data)
                 self?.delegate?.writerImageStringData.onNext(decodeResponse.image)
                 self?.delegate?.writerNameData.onNext(decodeResponse.writer)
-                self?.delegate?.commentData.onNext(decodeResponse.comment)
+                self?.delegate?.commentData.accept(decodeResponse.comment)
             case .failure(let error):
                 print("comment = \(error.localizedDescription)")
             }

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
+import RxRelay
 import RxSwift
 import Alamofire
-import RxRelay
 
 protocol CommentDataProtocol: AnyObject {
     var writerNameData: PublishSubject<String> { get set  }

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -11,20 +11,20 @@ protocol CommentDataProtocol: AnyObject {
 final class DetailPostViewModel: BaseViewModel {
     weak var delegate: CommentDataProtocol?
     
-    func deleteComment(postIdx: Int, commentIdx: Int, completion: @escaping () -> ()) {
-        print(commentIdx)
+    func deleteComment(postIdx: Int, commentIdx: Int, completion: @escaping (Result<Void, Error>) -> ()) {
         let url = APIConstants.deleteCommentURL + "\(postIdx)/" + "\(commentIdx)"
         AF.request(url,
                    method: .delete,
                    encoding: URLEncoding.queryString,
                    interceptor: JwtRequestInterceptor())
         .validate()
-        .responseData(emptyResponseCodes: [200, 201, 204]) { [weak self] response in
+        .responseData(emptyResponseCodes: [200, 201, 204]) { response in
             switch response.result {
             case .success:
                 print("success")
-                completion()
+                completion(.success(()))
             case .failure(let error):
+                completion(.failure(error))
                 print(error)
             }
         }

--- a/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
+++ b/Sources/Present/Main/AddPost/ViewController/AddPostViewController.swift
@@ -176,7 +176,7 @@ final class AddPostViewController: BaseVC<AddPostViewModel> {
         }
 
         viewModel.createPost(title: title, content: content, firstImage: firstImage, secondImage: secondImage, firstVotingOption: firstVotingOption, secondVotingOtion: secondVotingOtion)
-        LoadingIndicator.showLoading()
+        LoadingIndicator.showLoading(text: "게시 중")
     }
     
     override func configureVC() {

--- a/Sources/Util/Class/LoadingIndicator.swift
+++ b/Sources/Util/Class/LoadingIndicator.swift
@@ -2,7 +2,7 @@ import UIKit
 
 final class LoadingIndicator {
     private init() {}
-    static func showLoading() {
+    static func showLoading(text: String) {
         DispatchQueue.main.async {
             guard let window = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.last else { return }
             let loadingIndicatorView: UIActivityIndicatorView
@@ -14,7 +14,7 @@ final class LoadingIndicator {
                 loadingIndicatorView.color = .black
                 loadingIndicatorView.frame = window.frame
                 loadingLabel.frame = window.frame.offsetBy(dx: window.center.x - 23, dy: 40)
-                loadingLabel.text = "게시 중"
+                loadingLabel.text = text
                 window.addSubviews(loadingIndicatorView, loadingLabel)
             }
             loadingIndicatorView.startAnimating()

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
@@ -11,7 +11,6 @@ public extension TargetDependency.SPM {
     static let RxSwift = TargetDependency.package(product: "RxSwift")
     static let RxCocoa = TargetDependency.package(product: "RxCocoa")
     static let Alamofire = TargetDependency.package(product: "Alamofire")
-    static let RxDataSources = TargetDependency.package(product: "RxDataSources")
 }
 
 public extension Package {
@@ -33,7 +32,4 @@ public extension Package {
     static let Alamofire = Package.remote(
         url: "https://github.com/Alamofire/Alamofire",
         requirement: .upToNextMajor(from: "5.6.4"))
-    static let RxDataSources = Package.remote(
-        url: "https://github.com/RxSwiftCommunity/RxDataSources",
-        requirement: .upToNextMajor(from: "5.0.2"))
 }

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
@@ -11,6 +11,7 @@ public extension TargetDependency.SPM {
     static let RxSwift = TargetDependency.package(product: "RxSwift")
     static let RxCocoa = TargetDependency.package(product: "RxCocoa")
     static let Alamofire = TargetDependency.package(product: "Alamofire")
+    static let RxDataSources = TargetDependency.package(product: "RxDataSources")
 }
 
 public extension Package {
@@ -32,4 +33,7 @@ public extension Package {
     static let Alamofire = Package.remote(
         url: "https://github.com/Alamofire/Alamofire",
         requirement: .upToNextMajor(from: "5.6.4"))
+    static let RxDataSources = Package.remote(
+        url: "https://github.com/RxSwiftCommunity/RxDataSources",
+        requirement: .upToNextMajor(from: "5.0.2"))
 }


### PR DESCRIPTION
## 제목
게시물 삭제 기능을 구현했습니다.

## 작업 내용
자신이 적은 댓글만 삭제가 가능합니다.
내 댓글이 아닐 경우 swipe action 이 동작하지 않습니다.
<img width="258" alt="스크린샷 2023-04-05 오후 5 10 03" src="https://user-images.githubusercontent.com/81687906/230021121-a2fc259a-3c1b-465a-96c0-c58605e8022a.png">

## 변경사항(API)
게시물 상세페이지 - 댓글 API 가 변경되었습니다.
[Backend - #122](https://github.com/SLTDV/Choice-BackEnd/issues/122)
- 추가: isMine