### PR TITLE
변경된 댓글 생성 UI 적용 및 생성 조건 수정

### DIFF
--- a/Sources/Network/APIConstants.swift
+++ b/Sources/Network/APIConstants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct APIConstants {
-    static let baseURL = "http://10.82.17.76:81/"
+    static let baseURL = "https://port-0-choice-backend-p8xrq2mlfhw9efx.sel3.cloudtype.app/"
     
     //SignIn
     static let signInURL = baseURL + "auth/signin"

--- a/Sources/Present/Detail/ViewController/AddCommentView.swift
+++ b/Sources/Present/Detail/ViewController/AddCommentView.swift
@@ -1,5 +1,0 @@
-import UIKit
-
-class AddCommentView: UIView {
-    
-}

--- a/Sources/Present/Detail/ViewController/AddCommentView.swift
+++ b/Sources/Present/Detail/ViewController/AddCommentView.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+class AddCommentView: UIView {
+    
+}

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -93,8 +93,9 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private let submitCommentButton = UIButton().then {
+        $0.isEnabled = false
         $0.setTitle("게시", for: .normal)
-        $0.setTitleColor(.blue, for: .normal)
+        $0.setTitleColor(ChoiceAsset.Colors.grayDark.color, for: .normal)
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .regular)
     }
     
@@ -372,32 +373,50 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
 
 extension DetailPostViewController: UITextViewDelegate {
     private func setTextViewPlaceholder() {
-        if enterCommentTextView.text.isEmpty {
-            enterCommentTextView.text = "댓글을 입력해주세요."
-            enterCommentTextView.textColor = UIColor.lightGray
-        } else if enterCommentTextView.text == "댓글을 입력해주세요."{
-            enterCommentTextView.text = ""
-            enterCommentTextView.textColor = UIColor.black
-        }
+        
+        
+        
+        
+        
+        
+        
+        
+        
+//        if enterCommentTextView.text.trimmingCharacters(in: .whitespaces).isEmpty {
+//            enterCommentTextView.text = "댓글을 입력해주세요."
+//            enterCommentTextView.textColor = UIColor.lightGray
+//            submitCommentButton.isEnabled = false
+//            submitCommentButton.setTitleColor(ChoiceAsset.Colors.grayDark.color, for: .normal)
+//        } else if enterCommentTextView.text == "댓글을 입력해주세요." {
+//            enterCommentTextView.text = ""
+//            enterCommentTextView.textColor = UIColor.black
+//            submitCommentButton.isEnabled = true
+//            submitCommentButton.setTitleColor(.blue, for: .normal)
+//        }
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
-        setTextViewPlaceholder()
+        if enterCommentTextView.text == "댓글을 입력해주세요." {
+            enterCommentTextView.text = ""
+            enterCommentTextView.textColor = UIColor.black
+            submitCommentButton.isEnabled = true
+            submitCommentButton.setTitleColor(.blue, for: .normal)
+        }
+//        setTextViewPlaceholder()
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text == "" {
-            setTextViewPlaceholder()
+        if textView.text.trimmingCharacters(in: .whitespaces) == "" {
+            enterCommentTextView.text = "댓글을 입력해주세요."
+            enterCommentTextView.textColor = UIColor.lightGray
+            submitCommentButton.isEnabled = false
+            submitCommentButton.setTitleColor(ChoiceAsset.Colors.grayDark.color, for: .normal)
         }
     }
     
     func textViewDidChange(_ textView: UITextView) {
         let fixedWidth = textView.frame.width
         let size = CGSize(width: fixedWidth, height: textView.frame.height)
-        print("size height = \(size.height)")
-        
-//        textView.sizeThatFits(size)
-//        textView.reloadInputViews()
         whiteBackgroundView.sizeThatFits(size)
     }
 }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -161,9 +161,10 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     
     private func submitComment() {
         guard let idx = model?.idx else { return }
-        guard let content = enterCommentTextView.text?.trimmingCharacters(in: .whitespaces) else { return }
+        guard let content = enterCommentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
         
         LoadingIndicator.showLoading(text: "게시 중")
+        print("comment = \(content.count)")
         viewModel.createComment(idx: idx, content: content) {
             DispatchQueue.main.async {
                 self.viewModel.callToCommentData(idx: idx)
@@ -410,7 +411,7 @@ extension DetailPostViewController: UITextViewDelegate {
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.trimmingCharacters(in: .whitespaces) == "" {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines) == "" {
             enterCommentTextView.text = "댓글을 입력해주세요."
             enterCommentTextView.textColor = UIColor.lightGray
             setDefaultSubmitButton()
@@ -422,7 +423,7 @@ extension DetailPostViewController: UITextViewDelegate {
         let size = CGSize(width: fixedWidth, height: textView.frame.height)
         whiteBackgroundView.sizeThatFits(size)
         
-        if enterCommentTextView.text.trimmingCharacters(in: .whitespaces).count >= 1 {
+        if enterCommentTextView.text.trimmingCharacters(in: .whitespacesAndNewlines).count >= 1 {
             submitCommentButton.isEnabled = true
             submitCommentButton.setTitleColor(.blue, for: .normal)
         } else {

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -144,7 +144,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     
     private func submitComment() {
         guard let idx = model?.idx else { return }
-        guard let content = enterCommentTextView.text else { return }
+        guard let content = enterCommentTextView.text?.trimmingCharacters(in: .whitespaces) else { return }
         
         LoadingIndicator.showLoading(text: "게시 중")
         viewModel.createComment(idx: idx, content: content) {
@@ -372,45 +372,23 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
 }
 
 extension DetailPostViewController: UITextViewDelegate {
-    private func setTextViewPlaceholder() {
-        
-        
-        
-        
-        
-        
-        
-        
-        
-//        if enterCommentTextView.text.trimmingCharacters(in: .whitespaces).isEmpty {
-//            enterCommentTextView.text = "댓글을 입력해주세요."
-//            enterCommentTextView.textColor = UIColor.lightGray
-//            submitCommentButton.isEnabled = false
-//            submitCommentButton.setTitleColor(ChoiceAsset.Colors.grayDark.color, for: .normal)
-//        } else if enterCommentTextView.text == "댓글을 입력해주세요." {
-//            enterCommentTextView.text = ""
-//            enterCommentTextView.textColor = UIColor.black
-//            submitCommentButton.isEnabled = true
-//            submitCommentButton.setTitleColor(.blue, for: .normal)
-//        }
+    private func setDefaultSubmitButton() {
+        submitCommentButton.isEnabled = false
+        submitCommentButton.setTitleColor(ChoiceAsset.Colors.grayDark.color, for: .normal)
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {
         if enterCommentTextView.text == "댓글을 입력해주세요." {
             enterCommentTextView.text = ""
             enterCommentTextView.textColor = UIColor.black
-            submitCommentButton.isEnabled = true
-            submitCommentButton.setTitleColor(.blue, for: .normal)
         }
-//        setTextViewPlaceholder()
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespaces) == "" {
             enterCommentTextView.text = "댓글을 입력해주세요."
             enterCommentTextView.textColor = UIColor.lightGray
-            submitCommentButton.isEnabled = false
-            submitCommentButton.setTitleColor(ChoiceAsset.Colors.grayDark.color, for: .normal)
+            setDefaultSubmitButton()
         }
     }
     
@@ -418,6 +396,13 @@ extension DetailPostViewController: UITextViewDelegate {
         let fixedWidth = textView.frame.width
         let size = CGSize(width: fixedWidth, height: textView.frame.height)
         whiteBackgroundView.sizeThatFits(size)
+        
+        if enterCommentTextView.text.trimmingCharacters(in: .whitespaces).count >= 1 {
+            submitCommentButton.isEnabled = true
+            submitCommentButton.setTitleColor(.blue, for: .normal)
+        } else {
+            setDefaultSubmitButton()
+        }
     }
 }
 

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -82,11 +82,12 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private let enterCommentTextView = UITextView().then {
-        $0.text = "댓글을 입력해주세요"
+        $0.textContainerInset = UIEdgeInsets(top: 13, left: 14, bottom: 14, right: 14)
+        $0.text = "댓글을 입력해주세요."
         $0.isScrollEnabled = false
         $0.font = .systemFont(ofSize: 14)
         $0.textColor = .lightGray
-        $0.layer.cornerRadius = 25
+        $0.layer.cornerRadius = 22
         $0.layer.borderWidth = 1
         $0.layer.borderColor = ChoiceAsset.Colors.grayDark.color.cgColor
     }
@@ -357,7 +358,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         }
         
         enterCommentTextView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(10)
+            $0.top.equalToSuperview().inset(5)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().inset(43)
         }
@@ -370,12 +371,11 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
 }
 
 extension DetailPostViewController: UITextViewDelegate {
-    
     private func setTextViewPlaceholder() {
         if enterCommentTextView.text.isEmpty {
-            enterCommentTextView.text = "댓글을 입력해주세요"
+            enterCommentTextView.text = "댓글을 입력해주세요."
             enterCommentTextView.textColor = UIColor.lightGray
-        } else if enterCommentTextView.text == "댓글을 입력해주세요"{
+        } else if enterCommentTextView.text == "댓글을 입력해주세요."{
             enterCommentTextView.text = ""
             enterCommentTextView.textColor = UIColor.black
         }
@@ -393,8 +393,12 @@ extension DetailPostViewController: UITextViewDelegate {
     
     func textViewDidChange(_ textView: UITextView) {
         let fixedWidth = textView.frame.width
-        let size = CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude)
-        whiteBackgroundView.frame.size = CGSize(width: max(size.width, fixedWidth), height: size.height)
+        let size = CGSize(width: fixedWidth, height: textView.frame.height)
+        print("size height = \(size.height)")
+        
+//        textView.sizeThatFits(size)
+//        textView.reloadInputViews()
+        whiteBackgroundView.sizeThatFits(size)
     }
 }
 

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -168,6 +168,8 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             DispatchQueue.main.async {
                 self.viewModel.callToCommentData(idx: idx)
                 self.commentTableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
+                self.enterCommentTextView.text = ""
+                self.setDefaultSubmitButton()
             }
             LoadingIndicator.hideLoading()
         }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -124,8 +124,8 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     
     @objc func keyboardUp(_ notification: NSNotification) {
         if let keyboardFrame:NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-           let keyboardRectangle = keyboardFrame.cgRectValue
-       
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            
             UIView.animate(
                 withDuration: 0.3
                 , animations: {
@@ -160,7 +160,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         
         enterCommentTextView.rx.didBeginEditing
             .bind(with: self, onNext: { owner, _ in
-                print("begin")
                 if owner.enterCommentTextView.text == "댓글을 입력해주세요." {
                     owner.enterCommentTextView.text = ""
                     owner.enterCommentTextView.textColor = UIColor.black
@@ -169,7 +168,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         
         enterCommentTextView.rx.didEndEditing
             .bind(with: self, onNext: { owner, _ in
-                print("didend")
                 if owner.enterCommentTextView.text.trimmingCharacters(in: .whitespacesAndNewlines) == "" {
                     owner.enterCommentTextView.text = "댓글을 입력해주세요."
                     owner.enterCommentTextView.textColor = UIColor.lightGray
@@ -178,23 +176,16 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             }).disposed(by: disposeBag)
         
         enterCommentTextView.rx.didChange
-            .bind(with: self, onNext: { owner, arg in
-                let fixedWidth = owner.enterCommentTextView.frame.height
-                let size = CGSize(width: fixedWidth, height: owner.enterCommentTextView.frame.height)
-                let countNewline = owner.enterCommentTextView.text.filter { $0 == "\n" }
-                
-                if countNewline.count > 3 {
-                    owner.enterCommentTextView.snp.makeConstraints {
-                        $0.height.equalTo(94)
-                    }
-                    owner.enterCommentTextView.isScrollEnabled = true
-                } else {
-                    owner.enterCommentTextView.sizeThatFits(CGSize(width: fixedWidth,
-                                                                   height: owner.enterCommentTextView.frame.height
-                                                                  ))
-                    owner.enterCommentTextView.isScrollEnabled = false
+            .bind(with: self, onNext: { owner, _ in
+                let maxHeight = 94.0
+                let fixedWidth = owner.enterCommentTextView.frame.size.width
+                let size = owner.enterCommentTextView.sizeThatFits(CGSize(width: fixedWidth, height: .infinity))
+
+                owner.enterCommentTextView.isScrollEnabled = size.height > maxHeight
+                owner.enterCommentTextView.snp.updateConstraints {
+                    $0.height.equalTo(min(maxHeight, size.height))
                 }
-                
+
                 if owner.enterCommentTextView.text.trimmingCharacters(in: .whitespacesAndNewlines).count >= 1 {
                     owner.submitCommentButton.isEnabled = true
                     owner.submitCommentButton.setTitleColor(.blue, for: .normal)
@@ -209,7 +200,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         guard let content = enterCommentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
         
         LoadingIndicator.showLoading(text: "게시 중")
-        print("comment = \(content.count)")
         viewModel.createComment(idx: idx, content: content) {
             DispatchQueue.main.async {
                 self.viewModel.callToCommentData(idx: idx)
@@ -415,7 +405,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             $0.leading.trailing.equalToSuperview().inset(38)
             $0.height.equalTo(1)
         }
-
+        
         commentTableView.snp.makeConstraints {
             $0.top.equalTo(divideCommentLineView).offset(32)
             $0.leading.trailing.equalToSuperview()
@@ -430,6 +420,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         
         enterCommentTextView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(5)
+            $0.height.equalTo(47)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().inset(33)
         }
@@ -458,8 +449,8 @@ extension DetailPostViewController: UITableViewDelegate {
                 case .success(()):
                     self?.viewModel.callToCommentData(idx: self!.model!.idx)
                     self?.commentTableView.reloadRows(
-                    at: [indexPath],
-                    with: .automatic
+                        at: [indexPath],
+                        with: .automatic
                     )
                 case .failure(let error):
                     print("Delete Faield = \(error.localizedDescription)")
@@ -467,7 +458,7 @@ extension DetailPostViewController: UITableViewDelegate {
             })
         })
         contextual.image = UIImage(systemName: "trash")
-
+        
         if commentModel.isMine {
             config = UISwipeActionsConfiguration(actions: [contextual])
         }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -76,26 +76,24 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         $0.backgroundColor = .black
     }
     
-    private let commentCountLabel = UILabel().then {
-        $0.text = "댓글"
-        $0.font = .systemFont(ofSize: 14, weight: .medium)
+    private let whiteBackgroundView = UIView().then {
+        $0.backgroundColor = .white
     }
     
     private let enterCommentTextView = UITextView().then {
         $0.text = "댓글을 입력해주세요"
         $0.font = .systemFont(ofSize: 14)
         $0.textColor = .lightGray
-        $0.layer.cornerRadius = 10
+        $0.layer.cornerRadius = 25
         $0.layer.borderWidth = 1
-        $0.layer.borderColor = .init(red: 0.629, green: 0.629, blue: 0.629, alpha: 1)
+        $0.layer.borderColor = ChoiceAsset.Colors.grayDark.color.cgColor
     }
     
     private let enterCommentButton = UIButton().then {
         $0.setTitle("게시", for: .normal)
+        $0.setTitleColor(.blue, for: .normal)
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .regular)
-        $0.layer.cornerRadius = 10
-        $0.backgroundColor = .black
-        $0.isHidden = false
+        $0.backgroundColor = .red
     }
     
     private let commentTableView = UITableView().then {
@@ -253,16 +251,17 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     override func addView() {
-        view.addSubview(scrollView)
+        view.addSubviews(scrollView, whiteBackgroundView)
         scrollView.addSubview(contentView)
         contentView.addSubviews(userImageView, userNameLabel,titleLabel,
                                 divideVotePostImageLineView, descriptionLabel,
                                 firstPostImageView, secondPostImageView,
                                 firstVoteButton, secondVoteButton,
-                                divideCommentLineView, commentCountLabel,
-                                enterCommentTextView, enterCommentButton, commentTableView)
+                                divideCommentLineView, commentTableView)
         firstPostImageView.addSubview(firstVoteOptionBackgroundView)
         secondPostImageView.addSubview(secondVoteOptionBackgroundView)
+        whiteBackgroundView.addSubview(enterCommentTextView)
+        enterCommentTextView.addSubview(enterCommentButton)
     }
     
     override func setLayout() {
@@ -344,30 +343,29 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             $0.leading.trailing.equalToSuperview().inset(38)
             $0.height.equalTo(1)
         }
-        
-        commentCountLabel.snp.makeConstraints {
-            $0.top.equalTo(divideCommentLineView.snp.bottom).offset(18)
-            $0.leading.equalToSuperview().offset(30)
-        }
-        
-        enterCommentTextView.snp.makeConstraints {
-            $0.top.equalTo(commentCountLabel.snp.bottom).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(30)
-            $0.height.equalTo(83)
-        }
-        
-        enterCommentButton.snp.makeConstraints {
-            $0.top.equalTo(enterCommentTextView.snp.bottom).offset(10)
-            $0.trailing.equalTo(enterCommentTextView.snp.trailing)
-            $0.leading.equalTo(enterCommentTextView.snp.leading).inset(250)
-            $0.height.equalTo(30)
-        }
-        
+
         commentTableView.snp.makeConstraints {
-            $0.top.equalTo(enterCommentButton.snp.bottom).offset(30)
+            $0.top.equalTo(divideCommentLineView).offset(32)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()
             $0.height.equalTo(1)
+        }
+        
+        whiteBackgroundView.snp.makeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(100)
+        }
+        
+        enterCommentTextView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(10)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(43)
+        }
+        
+        enterCommentButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview()
         }
     }
 }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -77,11 +77,13 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private let whiteBackgroundView = UIView().then {
+        $0.autoresizingMask = .flexibleHeight
         $0.backgroundColor = .white
     }
     
     private let enterCommentTextView = UITextView().then {
         $0.text = "댓글을 입력해주세요"
+        $0.isScrollEnabled = false
         $0.font = .systemFont(ofSize: 14)
         $0.textColor = .lightGray
         $0.layer.cornerRadius = 25
@@ -352,7 +354,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         whiteBackgroundView.snp.makeConstraints {
             $0.bottom.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(100)
         }
         
         enterCommentTextView.snp.makeConstraints {
@@ -369,6 +370,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
 }
 
 extension DetailPostViewController: UITextViewDelegate {
+    
     private func setTextViewPlaceholder() {
         if enterCommentTextView.text.isEmpty {
             enterCommentTextView.text = "댓글을 입력해주세요"
@@ -387,6 +389,12 @@ extension DetailPostViewController: UITextViewDelegate {
         if textView.text == "" {
             setTextViewPlaceholder()
         }
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        let fixedWidth = textView.frame.width
+        let size = CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude)
+        whiteBackgroundView.frame.size = CGSize(width: max(size.width, fixedWidth), height: size.height)
     }
 }
 

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -93,7 +93,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         $0.setTitle("게시", for: .normal)
         $0.setTitleColor(.blue, for: .normal)
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .regular)
-        $0.backgroundColor = .red
     }
     
     private let commentTableView = UITableView().then {
@@ -260,8 +259,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                                 divideCommentLineView, commentTableView)
         firstPostImageView.addSubview(firstVoteOptionBackgroundView)
         secondPostImageView.addSubview(secondVoteOptionBackgroundView)
-        whiteBackgroundView.addSubview(enterCommentTextView)
-        enterCommentTextView.addSubview(enterCommentButton)
+        whiteBackgroundView.addSubviews(enterCommentTextView, enterCommentButton)
     }
     
     override func setLayout() {
@@ -364,8 +362,8 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         }
         
         enterCommentButton.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview()
+            $0.centerY.equalTo(enterCommentTextView)
+            $0.trailing.equalTo(enterCommentTextView).inset(17)
         }
     }
 }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -156,7 +156,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         }
     }
     
-    private func submitcommentButtonDidTap() {
+    private func submitCommentButtonDidTap() {
         submitCommentButton.rx.tap
             .bind(with: self, onNext: { owner, _ in
                 owner.submitComment()
@@ -249,7 +249,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         
         bindTableView()
         bindUI()
-        submitcommentButtonDidTap()
+        submitCommentButtonDidTap()
         changePostData(model: model!)
     }
     

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -122,6 +122,23 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         self.view.endEditing(true)
     }
     
+    @objc func keyboardUp(_ notification: NSNotification) {
+        if let keyboardFrame:NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+           let keyboardRectangle = keyboardFrame.cgRectValue
+       
+            UIView.animate(
+                withDuration: 0.3
+                , animations: {
+                    self.view.transform = CGAffineTransform(translationX: 0, y: -keyboardRectangle.height)
+                }
+            )
+        }
+    }
+    
+    @objc func keyboardDown(_ notification: NSNotification) {
+        self.view.transform = .identity
+    }
+    
     private func bindTableView() {
         commentData.bind(to: commentTableView.rx.items(cellIdentifier: CommentCell.identifier,
                                                        cellType: CommentCell.self)) { (row, data, cell) in
@@ -156,7 +173,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         }
     }
     
-    private func submitCommentButtonDidTap() {
+    private func submitcommentButtonDidTap() {
         submitCommentButton.rx.tap
             .bind(with: self, onNext: { owner, _ in
                 owner.submitComment()
@@ -223,11 +240,17 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.commentTableView.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardUp), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDown), name: UIResponder.keyboardWillHideNotification, object: nil)
+        
+        
         viewModel.callToCommentData(idx: model!.idx)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         self.commentTableView.removeObserver(self, forKeyPath: "contentSize")
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
@@ -249,7 +272,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         
         bindTableView()
         bindUI()
-        submitCommentButtonDidTap()
+        submitcommentButtonDidTap()
         changePostData(model: model!)
     }
     
@@ -361,7 +384,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         enterCommentTextView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(5)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(43)
+            $0.bottom.equalToSuperview().inset(33)
         }
         
         submitCommentButton.snp.makeConstraints {

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -91,7 +91,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         $0.layer.borderColor = ChoiceAsset.Colors.grayDark.color.cgColor
     }
     
-    private let enterCommentButton = UIButton().then {
+    private let submitCommentButton = UIButton().then {
         $0.setTitle("게시", for: .normal)
         $0.setTitleColor(.blue, for: .normal)
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: .regular)
@@ -140,7 +140,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         }).disposed(by: disposeBag)
     }
     
-    private func enterComment() {
+    private func submitComment() {
         guard let idx = model?.idx else { return }
         guard let content = enterCommentTextView.text else { return }
         
@@ -154,10 +154,10 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         }
     }
     
-    private func commentButtonDidTap() {
-        enterCommentButton.rx.tap
+    private func submitcommentButtonDidTap() {
+        submitCommentButton.rx.tap
             .bind(with: self, onNext: { owner, _ in
-                owner.enterComment()
+                owner.submitComment()
                 owner.viewModel.callToCommentData(idx: owner.model!.idx)
             }).disposed(by: disposeBag)
     }
@@ -247,7 +247,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         
         bindTableView()
         bindUI()
-        commentButtonDidTap()
+        submitcommentButtonDidTap()
         changePostData(model: model!)
     }
     
@@ -261,7 +261,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                                 divideCommentLineView, commentTableView)
         firstPostImageView.addSubview(firstVoteOptionBackgroundView)
         secondPostImageView.addSubview(secondVoteOptionBackgroundView)
-        whiteBackgroundView.addSubviews(enterCommentTextView, enterCommentButton)
+        whiteBackgroundView.addSubviews(enterCommentTextView, submitCommentButton)
     }
     
     override func setLayout() {
@@ -362,7 +362,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             $0.bottom.equalToSuperview().inset(43)
         }
         
-        enterCommentButton.snp.makeConstraints {
+        submitCommentButton.snp.makeConstraints {
             $0.centerY.equalTo(enterCommentTextView)
             $0.trailing.equalTo(enterCommentTextView).inset(17)
         }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -157,6 +157,51 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                 return
             }
         }).disposed(by: disposeBag)
+        
+        enterCommentTextView.rx.didBeginEditing
+            .bind(with: self, onNext: { owner, _ in
+                print("begin")
+                if owner.enterCommentTextView.text == "댓글을 입력해주세요." {
+                    owner.enterCommentTextView.text = ""
+                    owner.enterCommentTextView.textColor = UIColor.black
+                }
+            }).disposed(by: disposeBag)
+        
+        enterCommentTextView.rx.didEndEditing
+            .bind(with: self, onNext: { owner, _ in
+                print("didend")
+                if owner.enterCommentTextView.text.trimmingCharacters(in: .whitespacesAndNewlines) == "" {
+                    owner.enterCommentTextView.text = "댓글을 입력해주세요."
+                    owner.enterCommentTextView.textColor = UIColor.lightGray
+                    owner.setDefaultSubmitButton()
+                }
+            }).disposed(by: disposeBag)
+        
+        enterCommentTextView.rx.didChange
+            .bind(with: self, onNext: { owner, arg in
+                let fixedWidth = owner.enterCommentTextView.frame.height
+                let size = CGSize(width: fixedWidth, height: owner.enterCommentTextView.frame.height)
+                let countNewline = owner.enterCommentTextView.text.filter { $0 == "\n" }
+                
+                if countNewline.count > 3 {
+                    owner.enterCommentTextView.snp.makeConstraints {
+                        $0.height.equalTo(94)
+                    }
+                    owner.enterCommentTextView.isScrollEnabled = true
+                } else {
+                    owner.enterCommentTextView.sizeThatFits(CGSize(width: fixedWidth,
+                                                                   height: owner.enterCommentTextView.frame.height
+                                                                  ))
+                    owner.enterCommentTextView.isScrollEnabled = false
+                }
+                
+                if owner.enterCommentTextView.text.trimmingCharacters(in: .whitespacesAndNewlines).count >= 1 {
+                    owner.submitCommentButton.isEnabled = true
+                    owner.submitCommentButton.setTitleColor(.blue, for: .normal)
+                } else {
+                    owner.setDefaultSubmitButton()
+                }
+            }).disposed(by: disposeBag)
     }
     
     private func submitComment() {
@@ -269,7 +314,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     override func configureVC() {
-        enterCommentTextView.delegate = self
         viewModel.delegate = self
         commentTableView.delegate = self
         
@@ -397,38 +441,10 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
 }
 
-extension DetailPostViewController: UITextViewDelegate {
+extension DetailPostViewController {
     private func setDefaultSubmitButton() {
         submitCommentButton.isEnabled = false
         submitCommentButton.setTitleColor(ChoiceAsset.Colors.grayDark.color, for: .normal)
-    }
-    
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        if enterCommentTextView.text == "댓글을 입력해주세요." {
-            enterCommentTextView.text = ""
-            enterCommentTextView.textColor = UIColor.black
-        }
-    }
-    
-    func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines) == "" {
-            enterCommentTextView.text = "댓글을 입력해주세요."
-            enterCommentTextView.textColor = UIColor.lightGray
-            setDefaultSubmitButton()
-        }
-    }
-    
-    func textViewDidChange(_ textView: UITextView) {
-        let fixedWidth = textView.frame.width
-        let size = CGSize(width: fixedWidth, height: textView.frame.height)
-        whiteBackgroundView.sizeThatFits(size)
-        
-        if enterCommentTextView.text.trimmingCharacters(in: .whitespacesAndNewlines).count >= 1 {
-            submitCommentButton.isEnabled = true
-            submitCommentButton.setTitleColor(.blue, for: .normal)
-        } else {
-            setDefaultSubmitButton()
-        }
     }
 }
 


### PR DESCRIPTION
## 제목
댓글 생성 UI 변경사항을 적용하고, 댓글 생성 조건을 수정했습니다.

## 작업 내용
- 변경된 댓글 생성 UI 적용
TextView 의 height을 dynamic 하게 변경하도록 구현했습니다.
- 댓글 생성 조건 수정
before: 댓글을 입력하지 않아도 댓글을 생성할 수 있음 ('댓글을 입력해주세요.' 가 그대로 댓글로 생성됨)
after: 댓글을 입력하지 않으면 댓글을 생성할 수 없음, 좌우 공백은 제거함.
<div>
<img width="252" alt="스크린샷 2023-04-10 오후 2 51 34" src="https://user-images.githubusercontent.com/81687906/230835617-cf7db907-717e-4f1f-8186-6a854cd465fd.png">
<img width="257" alt="스크린샷 2023-04-10 오후 2 53 12" src="https://user-images.githubusercontent.com/81687906/230835861-a7f6a74d-0e14-459a-bf0c-8a6604eccd39.png">
</div

