### PR TITLE
게시물 정렬 관련

### DIFF
--- a/Sources/Present/Main/Home/ViewController/HomeViewController.swift
+++ b/Sources/Present/Main/Home/ViewController/HomeViewController.swift
@@ -6,7 +6,9 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
     private let disposeBag = DisposeBag()
     
     var postItemsData = PublishSubject<[PostModel]>()
-
+    
+    private var sortType: MenuOptionType = .findNewestPostData
+    
     private let leftLogoImageView = UIImageView().then {
         $0.image = ChoiceAsset.Images.homeLogo.image
     }
@@ -87,10 +89,20 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftLogoImageView)
         navigationItem.rightBarButtonItems = [profileButton, addPostButton]
         
-        let recentSort = UIAction(title: "최신순으로", image: UIImage(systemName: "clock"),
-                                  handler: { [weak self] _ in self?.callToFindAllData(type: .findNewestPostData)})
-        let popularSort = UIAction(title: "인기순으로", image: UIImage(systemName: "heart"),
-                                   handler: { [weak self] _ in self?.callToFindAllData(type: .findBestPostData)})
+        let recentSort = UIAction(title: "최신순으로", image: UIImage(systemName: "clock"), handler: { [weak self] _ in
+            self?.callToFindAllData(type: .findNewestPostData)
+            self?.sortType = .findNewestPostData
+            DispatchQueue.main.async {
+                self?.dropdownButton.setTitle("최신순 ↓", for: .normal)
+            }
+        })
+        let popularSort = UIAction(title: "인기순으로", image: UIImage(systemName: "heart"), handler: { [weak self] _ in
+            self?.callToFindAllData(type: .findBestPostData)
+            self?.sortType = .findBestPostData
+            DispatchQueue.main.async {
+                self?.dropdownButton.setTitle("인기순 ↓", for: .normal)
+            }
+        })
         
         dropdownButton.menu = UIMenu(title: "정렬", children: [recentSort, popularSort])
         
@@ -99,7 +111,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        callToFindAllData(type: .findNewestPostData)
+        callToFindAllData(type: sortType)
     }
     
     override func addView() {

--- a/Sources/Present/Main/Home/ViewController/HomeViewController.swift
+++ b/Sources/Present/Main/Home/ViewController/HomeViewController.swift
@@ -68,10 +68,6 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
             }).disposed(by: disposeBag)
     }
     
-    private func callToFindAllData(type: MenuOptionType) {
-        viewModel.callToFindData(type: type)
-    }
-    
     func postVoteButtonDidTap(idx: Int, choice: Int) {
         viewModel.callToAddVoteNumber(idx: idx, choice: choice)
     }
@@ -90,14 +86,14 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
         navigationItem.rightBarButtonItems = [profileButton, addPostButton]
         
         let recentSort = UIAction(title: "최신순으로", image: UIImage(systemName: "clock"), handler: { [weak self] _ in
-            self?.callToFindAllData(type: .findNewestPostData)
+            self?.viewModel.callToFindData(type: .findNewestPostData)
             self?.sortType = .findNewestPostData
             DispatchQueue.main.async {
                 self?.dropdownButton.setTitle("최신순 ↓", for: .normal)
             }
         })
         let popularSort = UIAction(title: "인기순으로", image: UIImage(systemName: "heart"), handler: { [weak self] _ in
-            self?.callToFindAllData(type: .findBestPostData)
+            self?.viewModel.callToFindData(type: .findBestPostData)
             self?.sortType = .findBestPostData
             DispatchQueue.main.async {
                 self?.dropdownButton.setTitle("인기순 ↓", for: .normal)
@@ -111,7 +107,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        callToFindAllData(type: sortType)
+        viewModel.callToFindData(type: sortType)
     }
     
     override func addView() {

--- a/Sources/Present/Main/Home/ViewController/HomeViewController.swift
+++ b/Sources/Present/Main/Home/ViewController/HomeViewController.swift
@@ -32,7 +32,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
     
     private let dropdownButton = UIButton().then {
         $0.showsMenuAsPrimaryAction = true
-        $0.setTitle("정렬 ↓", for: .normal)
+        $0.setTitle("최신순 ↓", for: .normal)
         $0.setTitleColor(.black, for: .normal)
         $0.titleLabel?.font = .systemFont(ofSize: 12, weight: .semibold)
         $0.backgroundColor = .init(red: 0.94, green: 0.94, blue: 0.94, alpha: 1)

--- a/Sources/Present/Main/Profile/ViewModel/ProfileViewModel.swift
+++ b/Sources/Present/Main/Profile/ViewModel/ProfileViewModel.swift
@@ -23,10 +23,10 @@ final class ProfileViewModel: BaseViewModel {
         .responseData(emptyResponseCodes: [200, 201, 204]) { [weak self] response in
             switch response.result {
             case .success(let data):
-                let decodeResponse = try! JSONDecoder().decode(ProfileModel.self, from: data)
-                self?.delegate?.postListData.onNext(decodeResponse.postList ?? .init())
-                self?.delegate?.nicknameData.onNext(decodeResponse.nickname)
-                self?.delegate?.imageData.onNext(decodeResponse.image)
+                let decodeResponse = try? JSONDecoder().decode(ProfileModel.self, from: data)
+                self?.delegate?.postListData.onNext(decodeResponse?.postList ?? .init())
+                self?.delegate?.nicknameData.onNext(decodeResponse?.nickname ?? "")
+                self?.delegate?.imageData.onNext(decodeResponse?.image)
             case .failure(let error):
                 print("error = \(error.localizedDescription)")
             }


### PR DESCRIPTION
## 제목
다시 데이터를 불러 올 때 선택한 정렬 방법에 따라 정렬되도록 변경하였습니다.

## 작업 내용
이전에는 인기순으로 정렬을 했더라도 데이터를 다시 불러올 때 최신순으로 정렬 되었습니다.
-> 선택한 정렬 방법에 따라 다시 그 방법으로 불러오도록 함.

+ 선택한 정렬 방법에 따라 정렬 버튼 title 이 변경되도록 했습니다.
> default : 최신순 ↓
<img width="196" alt="스크린샷 2023-04-16 오후 10 17 26" src="https://user-images.githubusercontent.com/81687906/232314060-fad82894-7948-4508-aeae-177cd472f6aa.png">