### PR TITLE
Main - Pull to Refresh 기능 구현

### DIFF
--- a/Sources/Present/Main/Home/ViewController/HomeViewController.swift
+++ b/Sources/Present/Main/Home/ViewController/HomeViewController.swift
@@ -137,7 +137,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
         isLastPage = false
     }
     
-    func configureRefreshControl() {
+    private func configureRefreshControl() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self,
                                   action: #selector(handleRefreshControl(_:)),
@@ -145,7 +145,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
         postTableView.refreshControl = refreshControl
     }
     
-    func configureDropDown() {
+    private func configureDropDown() {
         let recentSort = UIAction(title: "최신순으로", image: UIImage(systemName: "clock"), handler: { [weak self] _ in
             LoadingIndicator.showLoading(text: "")
             self?.sortTableViewData(type: .findNewestPostData)

--- a/Sources/Present/Main/Home/ViewController/HomeViewController.swift
+++ b/Sources/Present/Main/Home/ViewController/HomeViewController.swift
@@ -137,6 +137,23 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
         isLastPage = false
     }
     
+    func configureRefreshControl() {
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self,
+                                  action: #selector(handleRefreshControl(_:)),
+                                  for: .valueChanged)
+        postTableView.refreshControl = refreshControl
+    }
+    
+    @objc private func handleRefreshControl(_ sender: UIRefreshControl) {
+        sortTableViewData(type: .findNewestPostData)
+        DispatchQueue.main.async {
+            self.postTableView.reloadData()
+            self.postData.accept([])
+            self.postTableView.refreshControl?.endRefreshing()
+        }
+    }
+    
     // MARK: - Override
     override func configureVC() {
         let navBarAppearance = UINavigationBarAppearance()
@@ -156,7 +173,6 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
             self?.sortTableViewData(type: .findNewestPostData)
             DispatchQueue.main.async {
                 self?.postTableView.reloadData()
-                self?.postTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
                 self?.postData.accept([])
                 self?.dropdownButton.setTitle("최신순 ↓", for: .normal)
             }
@@ -166,7 +182,6 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
             self?.sortTableViewData(type: .findBestPostData)
             DispatchQueue.main.async {
                 self?.postTableView.reloadData()
-                self?.postTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
                 self?.postData.accept([])
                 self?.dropdownButton.setTitle("인기순 ↓", for: .normal)
             }
@@ -178,6 +193,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
         bindTableView()
         navigationBarButtonDidTap()
         viewModel.requestPostData(type: sortType)
+        configureRefreshControl()
     }
 
     override func addView() {

--- a/Sources/Present/Main/Home/ViewController/HomeViewController.swift
+++ b/Sources/Present/Main/Home/ViewController/HomeViewController.swift
@@ -145,29 +145,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
         postTableView.refreshControl = refreshControl
     }
     
-    @objc private func handleRefreshControl(_ sender: UIRefreshControl) {
-        sortTableViewData(type: .findNewestPostData)
-        DispatchQueue.main.async {
-            self.postTableView.reloadData()
-            self.postData.accept([])
-            self.postTableView.refreshControl?.endRefreshing()
-        }
-    }
-    
-    // MARK: - Override
-    override func configureVC() {
-        let navBarAppearance = UINavigationBarAppearance()
-        navBarAppearance.backgroundColor = .white
-        navBarAppearance.shadowColor = .clear
-        
-        navigationController?.navigationBar.standardAppearance = navBarAppearance
-        navigationController?.navigationBar.scrollEdgeAppearance = navBarAppearance
-        
-        view.backgroundColor = .white
-        
-        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftLogoImageView)
-        navigationItem.rightBarButtonItems = [profileButton, addPostButton]
-        
+    func configureDropDown() {
         let recentSort = UIAction(title: "최신순으로", image: UIImage(systemName: "clock"), handler: { [weak self] _ in
             LoadingIndicator.showLoading(text: "")
             self?.sortTableViewData(type: .findNewestPostData)
@@ -188,6 +166,29 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
         })
         
         dropdownButton.menu = UIMenu(title: "정렬", children: [recentSort, popularSort])
+    }
+    
+    @objc private func handleRefreshControl(_ sender: UIRefreshControl) {
+        sortTableViewData(type: .findNewestPostData)
+        DispatchQueue.main.async {
+            self.postTableView.reloadData()
+            self.postData.accept([])
+            self.postTableView.refreshControl?.endRefreshing()
+        }
+    }
+    
+    // MARK: - Override
+    override func configureVC() {
+        let navBarAppearance = UINavigationBarAppearance()
+        navBarAppearance.backgroundColor = .white
+        navBarAppearance.shadowColor = .clear
+        navigationController?.navigationBar.standardAppearance = navBarAppearance
+        navigationController?.navigationBar.scrollEdgeAppearance = navBarAppearance
+        view.backgroundColor = .white
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftLogoImageView)
+        navigationItem.rightBarButtonItems = [profileButton, addPostButton]
+        
+        configureDropDown()
         
         viewModel.delegate = self
         bindTableView()


### PR DESCRIPTION
## 제목
메인페이지에서 ```Pull to Refresh``` 기능을 구현했습니다.

## 작업 내용
화면을 잡아당겨 Refresh하는 기능을 구현했습니다.

**굳이 이렇게 한 이유는..**
디테일 페이지 -> 메인페이지로 오게되면 테이블의 상태가 유지되어야합니다.
하지만 게시물 생성시엔 생성된 게시물이 바로 보여져야하기 때문에 ```viewWillAppear``` 에서 작업을 하기에는 문제가 있다고 생각되어
```Pull to Refresh```기능을 추가했습니다.

## 주의 사항
Pull to Refresh 동작 시 약간의 깜빡거림이 있음