### PR TITLE
댓글 pagination 적용

### DIFF
--- a/Sources/Present/Detail/Model/CommentModel.swift
+++ b/Sources/Present/Detail/Model/CommentModel.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 struct CommentModel: Codable {
-    var writer: String
-    var image: String?
     var page: Int
     var size: Int
+    var writer: String
+    var image: String?
     var comment : [CommentData]
 }
 

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -157,7 +157,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                 let contentHeight = owner.scrollView.contentSize.height
                 let yOffset = owner.scrollView.contentOffset.y
                 let frameHeight = owner.scrollView.frame.size.height
-                print("contentOffset")
+
                 if owner.isLastPage {
                     return
                 }
@@ -172,7 +172,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                             case .success(let size):
                                 owner.commentTableView.reloadData()
                                 if size != 10 {
-                                    print("up 10")
                                     owner.isLastPage = true
                                 }
                             case .failure(let error):

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -303,8 +303,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         self.commentTableView.addObserver(self, forKeyPath: "contentSize", options: .new, context: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardUp), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardDown), name: UIResponder.keyboardWillHideNotification, object: nil)
-        
-//        viewModel.requestCommentData(idx: model!.idx)
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -206,11 +206,13 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         
         LoadingIndicator.showLoading(text: "게시 중")
         viewModel.requestToCreateComment(idx: idx, content: content) {
-            DispatchQueue.main.async {
-                self.viewModel.requestCommentData(idx: idx)
-                self.commentTableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
-                self.enterCommentTextView.text = ""
-                self.setDefaultSubmitButton()
+            DispatchQueue.main.async { [weak self] in
+                self?.viewModel.requestCommentData(idx: idx)
+                self?.commentTableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
+                self?.commentTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
+                self?.viewModel.commentCurrentPage = -1
+                self?.enterCommentTextView.text = ""
+                self?.setDefaultSubmitButton()
             }
             LoadingIndicator.hideLoading()
         }
@@ -226,14 +228,14 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     private func changePostData(model: Posts) {
         guard let firstImageUrl = URL(string: model.firstImageUrl) else { return }
         guard let secondImageUrl = URL(string: model.secondImageUrl) else { return }
-        DispatchQueue.main.async {
-            self.titleLabel.text = model.title
-            self.contentLabel.text = model.content
-            self.firstVoteOptionLabel.text = model.firstVotingOption
-            self.secondVoteOptionLabel.text = model.secondVotingOption
-            self.firstPostImageView.kf.setImage(with: firstImageUrl)
-            self.secondPostImageView.kf.setImage(with: secondImageUrl)
-            self.setVoteButtonLayout(with: model)
+        DispatchQueue.main.async { [weak self] in
+            self?.titleLabel.text = model.title
+            self?.contentLabel.text = model.content
+            self?.firstVoteOptionLabel.text = model.firstVotingOption
+            self?.secondVoteOptionLabel.text = model.secondVotingOption
+            self?.firstPostImageView.kf.setImage(with: firstImageUrl)
+            self?.secondPostImageView.kf.setImage(with: secondImageUrl)
+            self?.setVoteButtonLayout(with: model)
         }
     }
     

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -205,9 +205,9 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         guard let content = enterCommentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
         
         LoadingIndicator.showLoading(text: "게시 중")
-        viewModel.createComment(idx: idx, content: content) {
+        viewModel.requestToCreateComment(idx: idx, content: content) {
             DispatchQueue.main.async {
-                self.viewModel.callToCommentData(idx: idx)
+                self.viewModel.requestCommentData(idx: idx)
                 self.commentTableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
                 self.enterCommentTextView.text = ""
                 self.setDefaultSubmitButton()
@@ -269,7 +269,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardUp), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardDown), name: UIResponder.keyboardWillHideNotification, object: nil)
         
-        viewModel.callToCommentData(idx: model!.idx)
+        viewModel.requestCommentData(idx: model!.idx)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -436,7 +436,7 @@ extension DetailPostViewController: UITableViewDelegate {
                                          completion: { [weak self] result in
                 switch result {
                 case .success(()):
-                    self?.viewModel.callToCommentData(idx: self!.model!.idx)
+                    self?.viewModel.requestCommentData(idx: self!.model!.idx)
                     DispatchQueue.main.async {
                         self?.commentTableView.reloadRows(
                             at: [indexPath],

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -431,7 +431,7 @@ extension DetailPostViewController: UITableViewDelegate {
         let commentModel = commentData.value[indexPath.row]
         
         lazy var deleteContextual = UIContextualAction(style: .destructive, title: nil, handler: { _, _, _ in
-            self.viewModel.RequestToDeleteComment(postIdx: self.model!.idx,
+            self.viewModel.requestToDeleteComment(postIdx: self.model!.idx,
                                          commentIdx: commentModel.idx,
                                          completion: { [weak self] result in
                 switch result {

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -431,7 +431,7 @@ extension DetailPostViewController: UITableViewDelegate {
         let commentModel = commentData.value[indexPath.row]
         
         lazy var deleteContextual = UIContextualAction(style: .destructive, title: nil, handler: { _, _, _ in
-            self.viewModel.deleteComment(postIdx: self.model!.idx,
+            self.viewModel.RequestToDeleteComment(postIdx: self.model!.idx,
                                          commentIdx: commentModel.idx,
                                          completion: { [weak self] result in
                 switch result {

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -29,7 +29,7 @@ final class DetailPostViewModel: BaseViewModel {
         }
     }
     
-    func callToCommentData(idx: Int) {
+    func requestCommentData(idx: Int) {
         let url = APIConstants.detailPostURL + "\(idx)"
         AF.request(url,
                    method: .get,
@@ -49,7 +49,7 @@ final class DetailPostViewModel: BaseViewModel {
         }
     }
     
-    func createComment(idx: Int, content: String, completion: @escaping () -> ()) {
+    func requestToCreateComment(idx: Int, content: String, completion: @escaping () -> ()) {
         let url = APIConstants.createCommentURL + "\(idx)"
         let params = [
             "content" : content

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -12,7 +12,7 @@ protocol CommentDataProtocol: AnyObject {
 final class DetailPostViewModel: BaseViewModel {
     weak var delegate: CommentDataProtocol?
     
-    func deleteComment(postIdx: Int, commentIdx: Int, completion: @escaping (Result<Void, Error>) -> ()) {
+    func RequestToDeleteComment(postIdx: Int, commentIdx: Int, completion: @escaping (Result<Void, Error>) -> ()) {
         let url = APIConstants.deleteCommentURL + "\(postIdx)/" + "\(commentIdx)"
         AF.request(url,
                    method: .delete,

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -36,7 +36,9 @@ final class DetailPostViewModel: BaseViewModel {
                 print(postData.page, postData.size)
                 self?.delegate?.writerImageStringData.onNext(postData.image)
                 self?.delegate?.writerNameData.onNext(postData.writer)
-                self?.delegate?.commentData.accept(postData.comment)
+                var relay = self?.delegate?.commentData.value
+                relay?.append(contentsOf: postData.comment)
+                self?.delegate?.commentData.accept(relay!)
             case .failure(let error):
                 print("comment = \(error.localizedDescription)")
             }

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -11,38 +11,30 @@ protocol CommentDataProtocol: AnyObject {
 
 final class DetailPostViewModel: BaseViewModel {
     weak var delegate: CommentDataProtocol?
-    
-    func RequestToDeleteComment(postIdx: Int, commentIdx: Int, completion: @escaping (Result<Void, Error>) -> ()) {
-        let url = APIConstants.deleteCommentURL + "\(postIdx)/" + "\(commentIdx)"
-        AF.request(url,
-                   method: .delete,
-                   encoding: URLEncoding.queryString,
-                   interceptor: JwtRequestInterceptor())
-        .validate()
-        .responseData(emptyResponseCodes: [200, 201, 204]) { response in
-            switch response.result {
-            case .success:
-                completion(.success(()))
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
-    }
+    var commentCurrentPage = -1
     
     func requestCommentData(idx: Int) {
         let url = APIConstants.detailPostURL + "\(idx)"
-        AF.request(url,
+        
+        commentCurrentPage += 1
+        let requestComment = PostRequest(page: commentCurrentPage)
+        
+        let page = URLQueryItem(name: "page", value: String(requestComment.page))
+        let size = URLQueryItem(name: "size", value: String(requestComment.size))
+        var components = URLComponents(string: url)
+        components?.queryItems = [page, size]
+        
+        AF.request(components!,
                    method: .get,
                    encoding: URLEncoding.queryString,
                    interceptor: JwtRequestInterceptor())
         .validate()
-        .responseData(emptyResponseCodes: [200, 201, 204]) { [weak self] response in
+        .responseDecodable(of: CommentModel.self) { [weak self] response in
             switch response.result {
-            case .success(let data):
-                let decodeResponse = try! JSONDecoder().decode(CommentModel.self, from: data)
-                self?.delegate?.writerImageStringData.onNext(decodeResponse.image)
-                self?.delegate?.writerNameData.onNext(decodeResponse.writer)
-                self?.delegate?.commentData.accept(decodeResponse.comment)
+            case .success(let postData):
+                self?.delegate?.writerImageStringData.onNext(postData.image)
+                self?.delegate?.writerNameData.onNext(postData.writer)
+                self?.delegate?.commentData.accept(postData.comment)
             case .failure(let error):
                 print("comment = \(error.localizedDescription)")
             }
@@ -67,6 +59,23 @@ final class DetailPostViewModel: BaseViewModel {
                 completion()
             case .failure(let error):
                 print("post error = \(String(describing: error.localizedDescription))")
+            }
+        }
+    }
+    
+    func requestToDeleteComment(postIdx: Int, commentIdx: Int, completion: @escaping (Result<Void, Error>) -> ()) {
+        let url = APIConstants.deleteCommentURL + "\(postIdx)/" + "\(commentIdx)"
+        AF.request(url,
+                   method: .delete,
+                   encoding: URLEncoding.queryString,
+                   interceptor: JwtRequestInterceptor())
+        .validate()
+        .responseData(emptyResponseCodes: [200, 201, 204]) { response in
+            switch response.result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }

--- a/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -13,7 +13,7 @@ final class DetailPostViewModel: BaseViewModel {
     weak var delegate: CommentDataProtocol?
     var commentCurrentPage = -1
     
-    func requestCommentData(idx: Int) {
+    func requestCommentData(idx: Int, completion: @escaping (Result<Int, Error>) -> Void = { _ in }) {
         let url = APIConstants.detailPostURL + "\(idx)"
         
         commentCurrentPage += 1
@@ -32,6 +32,8 @@ final class DetailPostViewModel: BaseViewModel {
         .responseDecodable(of: CommentModel.self) { [weak self] response in
             switch response.result {
             case .success(let postData):
+                completion(.success(postData.size))
+                print(postData.page, postData.size)
                 self?.delegate?.writerImageStringData.onNext(postData.image)
                 self?.delegate?.writerNameData.onNext(postData.writer)
                 self?.delegate?.commentData.accept(postData.comment)

--- a/Sources/Present/Main/Home/ViewController/HomeViewController.swift
+++ b/Sources/Present/Main/Home/ViewController/HomeViewController.swift
@@ -115,16 +115,6 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
         viewModel.requestVote(idx: idx, choice: choice)
     }
     
-    private func createSpinnerFooter() -> UIView {
-        let footerView = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 100))
-        let spinner = UIActivityIndicatorView()
-        spinner.center = footerView.center
-        footerView.addSubview(spinner)
-        spinner.startAnimating()
-        
-        return footerView
-    }
-    
     private func sortTableViewData(type: MenuOptionType) {
         switch type {
         case .findNewestPostData:
@@ -140,8 +130,8 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
     private func configureRefreshControl() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self,
-                                  action: #selector(handleRefreshControl(_:)),
-                                  for: .valueChanged)
+                                 action: #selector(handleRefreshControl(_:)),
+                                 for: .valueChanged)
         postTableView.refreshControl = refreshControl
     }
     
@@ -164,7 +154,6 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
                 self?.dropdownButton.setTitle("인기순 ↓", for: .normal)
             }
         })
-        
         dropdownButton.menu = UIMenu(title: "정렬", children: [recentSort, popularSort])
     }
     

--- a/Sources/Util/Extension/ViewController/UIViewController.swift
+++ b/Sources/Util/Extension/ViewController/UIViewController.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIViewController {
+    func createSpinnerFooter() -> UIView {
+        let footerView = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 100))
+        let spinner = UIActivityIndicatorView()
+        spinner.center = footerView.center
+        footerView.addSubview(spinner)
+        spinner.startAnimating()
+        
+        return footerView
+    }
+}


### PR DESCRIPTION
## 제목
댓글에 pagination 을 적용시켰습니다.

## 작업 내용
- 댓글 추가 시 tableView top 으로 scroll 됩니다.
> default size: 10

추가로 
DetailPostViewModel 의 메서드 네이밍을기존 callTo~ 로 했던 네이밍에서 request~로 변경했습니다.
함수 기능에 더 적합하다고 생각되어 변경했는데 어떻게 생각하시나요?


## 요청
가능하다면 전체 ViewModel 의 API 연동 메서드의 네이밍을 변경하면 좋겠습니다.
또한 API 서버 통신 로직은 따로 분리해서 작업하는게 어떨까요? 
현재 ViewModel 이 너무 무겁고, 중복되는 코드들이 많아서 분리하는게 좋을 것 같습니다.
