### PR TITLE
hotfix/comment pagination

### DIFF
--- a/Sources/Present/Detail/Cell/CommentCell.swift
+++ b/Sources/Present/Detail/Cell/CommentCell.swift
@@ -48,7 +48,6 @@ final class CommentCell: UITableViewCell {
         }
 
         nicknameLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(14)
             $0.centerY.equalTo(profileImageView)
             $0.leading.equalTo(profileImageView.snp.trailing).offset(8)
         }

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -241,7 +241,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         viewModel.requestToCreateComment(idx: idx, content: content) {
             DispatchQueue.main.async { [weak self] in
                 self?.viewModel.requestCommentData(idx: idx)
-                self?.commentTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
+//                self?.commentTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
                 self?.commentTableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
                 self?.commentData.accept([])
                 self?.enterCommentTextView.text = ""
@@ -469,7 +469,6 @@ extension DetailPostViewController: UITableViewDelegate {
                                          completion: { [weak self] result in
                 switch result {
                 case .success(()):
-                    self?.viewModel.requestCommentData(idx: self!.model!.idx)
                     DispatchQueue.main.async {
                         self?.commentTableView.reloadRows(
                             at: [indexPath],

--- a/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -241,7 +241,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         viewModel.requestToCreateComment(idx: idx, content: content) {
             DispatchQueue.main.async { [weak self] in
                 self?.viewModel.requestCommentData(idx: idx)
-//                self?.commentTableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
                 self?.commentTableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
                 self?.commentData.accept([])
                 self?.enterCommentTextView.text = ""


### PR DESCRIPTION
## 제목
첫 댓글 게시 시 생기는 에러를 해결했습니다.

## 작업 내용
게시물에 처음 댓글을 게시하면 에러 발생.
-> 댓글 게시 시 top 으로 scroll 하던 코드 제거

+ 추가로 댓글 삭제 시 page +1 로 댓글을 다시 요청하던 코드는 문제를 야기할 수 있어, 제거했습니다
