### PR TITLE
회원탈퇴 시 토큰 삭제

### DIFF
--- a/Projects/App/Sources/Present/Main/Profile/ViewController/ProfileViewController.swift
+++ b/Projects/App/Sources/Present/Main/Profile/ViewController/ProfileViewController.swift
@@ -97,7 +97,7 @@ final class ProfileViewController: BaseVC<ProfileViewModel>, ProfileDataProtocol
         
         let okayAction = UIAlertAction(title: "변경", style: .default) { [weak self] data in
             LoadingIndicator.showLoading(text: "")
-            self?.viewModel.callToChangeNickname(nickname: alert.textFields?[0].text ?? "")
+            self?.viewModel.requestToChangeNickname(nickname: alert.textFields?[0].text ?? "")
         }
         let cancelAction = UIAlertAction(title: "취소", style: .destructive)
         
@@ -112,7 +112,7 @@ final class ProfileViewController: BaseVC<ProfileViewModel>, ProfileDataProtocol
         let alert = UIAlertController(title: "회원탈퇴", message: "회원탈퇴 하시겠습니까?", preferredStyle: .alert)
         
         let okayAction = UIAlertAction(title: "탈퇴", style: .destructive) { [weak self] data in
-            self?.viewModel.callToDeleteData(type: .callToMembershipWithdrawal)
+            self?.viewModel.requestToDeleteProfileData(type: .callToMembershipWithdrawal)
         }
         let cancelAction = UIAlertAction(title: "취소", style: .default)
         
@@ -126,7 +126,7 @@ final class ProfileViewController: BaseVC<ProfileViewModel>, ProfileDataProtocol
         let alert = UIAlertController(title: "로그아웃", message: "로그아웃 하시겠습니까?", preferredStyle: .alert)
         
         let okayAction = UIAlertAction(title: "로그아웃", style: .destructive) { [weak self] data in
-            self?.viewModel.callToDeleteData(type: .callToLogout)
+            self?.viewModel.requestToDeleteProfileData(type: .callToLogout)
         }
         let cancelAction = UIAlertAction(title: "취소", style: .default)
         
@@ -144,7 +144,7 @@ final class ProfileViewController: BaseVC<ProfileViewModel>, ProfileDataProtocol
         imagePickerController.delegate = self
         
         bindTableView()
-        viewModel.callToProfileData()
+        viewModel.requestProfileData()
     }
     
     override func addView() {
@@ -204,7 +204,7 @@ extension ProfileViewController: UIImagePickerControllerDelegate, UINavigationCo
         }
         
         LoadingIndicator.showLoading(text: "")
-        viewModel.callToProfileImageUpload(profileImage: newImage)
+        viewModel.requestToUploadProfileImage(profileImage: newImage)
             .subscribe(with: self, onNext: { owner, response in
                 DispatchQueue.main.async {
                     owner.profileImageView.kf.setImage(with: URL(string: response.profileImageUrl))
@@ -218,7 +218,7 @@ extension ProfileViewController: PostTableViewCellButtonDelegate {
     func removePostButtonDidTap(postIdx: Int) {
         let alert = UIAlertController(title: "게시물 삭제", message: "삭제 하시겠습니까?", preferredStyle: .alert)
         let okayAction = UIAlertAction(title: "삭제", style: .destructive) { _ in
-            self.viewModel.callToDeletePost(postIdx: postIdx)
+            self.viewModel.requestToDeletePost(postIdx: postIdx)
         }
         let cancelAction = UIAlertAction(title: "취소", style: .default)
         

--- a/Projects/App/Sources/Present/Main/Profile/ViewModel/ProfileViewModel.swift
+++ b/Projects/App/Sources/Present/Main/Profile/ViewModel/ProfileViewModel.swift
@@ -80,6 +80,9 @@ final class ProfileViewModel: BaseViewModel {
             switch response.result {
             case .success:
                 self?.navigateToSignInVC()
+                if type == .callToMembershipWithdrawal {
+                    self?.container.deleteAll()
+                }
             case .failure(let error):
                 print("error = \(error.localizedDescription)")
             }

--- a/Projects/App/Sources/Present/Main/Profile/ViewModel/ProfileViewModel.swift
+++ b/Projects/App/Sources/Present/Main/Profile/ViewModel/ProfileViewModel.swift
@@ -18,7 +18,7 @@ final class ProfileViewModel: BaseViewModel {
     weak var delegate: ProfileDataProtocol?
     private let container = AppDelegate.container.resolve(JwtStore.self)!
     
-    func callToProfileData() {
+    func requestProfileData() {
         let url = APIConstants.profileURL
         
         AF.request(url,
@@ -38,7 +38,7 @@ final class ProfileViewModel: BaseViewModel {
         }
     }
     
-    func callToChangeNickname(nickname: String) {
+    func requestToChangeNickname(nickname: String) {
         let url = APIConstants.changeNicknameURL
         let params = [
             "nickname" : nickname
@@ -61,7 +61,7 @@ final class ProfileViewModel: BaseViewModel {
         }
     }
     
-    func callToDeleteData(type: OptionItemType) {
+    func requestToDeleteProfileData(type: OptionItemType) {
         lazy var url = ""
         
         switch type {
@@ -89,7 +89,7 @@ final class ProfileViewModel: BaseViewModel {
         }
     }
     
-    func callToProfileImageUpload(profileImage: UIImage) -> Observable<ProfileImageModel> {
+    func requestToUploadProfileImage(profileImage: UIImage) -> Observable<ProfileImageModel> {
         var url = APIConstants.profileImageUploadURL
         
         var headers: HTTPHeaders = ["Content-Type" : "multipart/form-data"]
@@ -137,7 +137,7 @@ final class ProfileViewModel: BaseViewModel {
         }
     }
     
-    func callToDeletePost(postIdx: Int) {
+    func requestToDeletePost(postIdx: Int) {
         let url = APIConstants.deletePostURL + "\(postIdx)"
         AF.request(url,
                    method: .delete,
@@ -147,7 +147,7 @@ final class ProfileViewModel: BaseViewModel {
         .responseData(emptyResponseCodes: [200, 201, 204]) { [weak self] response in
             switch response.result {
             case .success:
-                self?.callToProfileData()
+                self?.requestProfileData()
             case .failure(let error):
                 print("error = \(error.localizedDescription)")
             }


### PR DESCRIPTION
## 제목
회원탈퇴 시 토큰을 삭제하도록 구현했습니다.

## 이런 문제가 있었습니다.
기존 회원탈퇴 시 화면만 로그인으로 전환하고, 토큰은 삭제되지 않아 앱을 다시 실행했을 때 홈 화면으로 이동하게 되는 문제가 있었습니다.

## 이렇게 해결했습니다.
회원탈퇴 시 access, refresh 토큰을 모두 삭제해 기존 문제를 해결했습니다.

추가로 profileViewModel 에 있던 API 호출 메서드의 네이밍을 변경했습니다.
ex) ```callTo~``` -> ```requestTo~```