### PR TITLE
프로필 이미지 contentMode 설정

### DIFF
--- a/Projects/App/Sources/Present/Main/Profile/ViewController/ProfileViewController.swift
+++ b/Projects/App/Sources/Present/Main/Profile/ViewController/ProfileViewController.swift
@@ -29,6 +29,7 @@ final class ProfileViewController: BaseVC<ProfileViewModel>, ProfileDataProtocol
         $0.tintColor = .black
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 50
+        $0.contentMode = .scaleAspectFill
     }
     
     private lazy var editProfileImageButton = UIButton().then {


### PR DESCRIPTION
## 이런 문제가 있었습니다.
프로필 이미지의 ```contentMode```를 설정하지 않아 사진이 찌그러지는 현상이 있었습니다.

## 이렇게 해결했습니다.
프로필 이미지에 ```contentMode```를 ```.scaleAspectFill``` 로 설정하여 해결했습니다.