### PR TITLE
[피드백 #104] profile 페이지 layout / UI 수정 

### DIFF
--- a/Projects/App/Sources/Present/Main/Profile/ViewModel/ProfileViewModel.swift
+++ b/Projects/App/Sources/Present/Main/Profile/ViewModel/ProfileViewModel.swift
@@ -31,7 +31,7 @@ final class ProfileViewModel: BaseViewModel {
                 let decodeResponse = try? JSONDecoder().decode(ProfileModel.self, from: data)
                 self?.delegate?.postListData.accept(decodeResponse?.postList ?? .init())
                 self?.delegate?.nicknameData.onNext(decodeResponse?.nickname ?? "")
-                self?.delegate?.imageData.onNext(decodeResponse?.image)
+                self?.delegate?.imageData.onNext(decodeResponse?.image ?? "")
             case .failure(let error):
                 print("error = \(error.localizedDescription)")
             }


### PR DESCRIPTION
## 제목
- #104 Issues에 대한 PR 입니다.
프로필 이미지를 설정하지 않았을 때 프로필 페이지로 이동하면, 앱이 종료되는 이슈가 있었습니다.

## 작업 내용
- 프로필 이미지가 nil일 때 빈 문자열("")을 반환하도록했습니다.

빈 문자열을 URL 로 변환하면 nil이 반환되므로, compactMap 메서드에 의해 bind 메서드는 실행되지 않도록 했습니다.
따라서 프로필 이미지가 nil이라면 default Image 로 설정됩니다.