### PR TITLE
[피드백 #106] 댓글 LoadingIndicator 설정 및 Layout 수정

### DIFF
--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -443,7 +443,6 @@ extension DetailPostViewController {
         guard let idx = model?.idx else { return }
         guard let content = enterCommentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
         
-        LoadingIndicator.showLoading(text: "게시 중")
         viewModel.commentCurrentPage = -1
         viewModel.requestToCreateComment(idx: idx, content: content) { result in
             switch result {
@@ -460,13 +459,14 @@ extension DetailPostViewController {
             case .failure(let error):
                 print("post error = \(String(describing: error.localizedDescription))")
             }
+            LoadingIndicator.hideLoading()
         }
-        LoadingIndicator.hideLoading()
     }
     
     private func submitCommentButtonDidTap() {
         submitCommentButton.rx.tap
             .bind(with: self, onNext: { owner, _ in
+                LoadingIndicator.showLoading(text: "게시 중")
                 owner.submitComment()
             }).disposed(by: disposeBag)
     }

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -93,7 +93,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private let enterCommentTextView = UITextView().then {
-        $0.textContainerInset = UIEdgeInsets(top: 13, left: 14, bottom: 14, right: 14)
+        $0.textContainerInset = UIEdgeInsets(top: 13, left: 14, bottom: 14, right: 50)
         $0.text = "댓글을 입력해주세요."
         $0.isScrollEnabled = false
         $0.font = .systemFont(ofSize: 14)
@@ -119,7 +119,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     private let emptyLabel = UILabel().then {
         $0.text = """
         아직 댓글이 없습니다
-        댓글을 작성 해보세요!
+        댓글을 작성해 보세요!
         """
         $0.font = .systemFont(ofSize: 18, weight: .semibold)
         $0.textAlignment = .center
@@ -387,12 +387,12 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         }
         
         firstVoteOptionLabel.snp.makeConstraints {
-            $0.top.equalTo(contentLabel.snp.bottom).offset(40)
+            $0.top.equalTo(contentLabel.snp.bottom).offset(30)
             $0.centerX.equalTo(firstPostImageView)
         }
         
         secondVoteOptionLabel.snp.makeConstraints {
-            $0.top.equalTo(contentLabel.snp.bottom).offset(40)
+            $0.top.equalTo(contentLabel.snp.bottom).offset(30)
             $0.centerX.equalTo(secondPostImageView)
         }
         

--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -2,25 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -39,6 +20,23 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -58,5 +56,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 제목
- #106 Issue에 대한 PR 입니다.
## 작업 내용
- 댓글 게시 중 LoadingIndicator를 표시하여 네트워크가 원활하지 않는 환경에서 연속으로 댓글이 게시되는 Issue를 해결했습니다.
- 댓글입력 textView에 많은 text를 입력할 시 게시 버튼을 침범하는 layout Issue를 해결했습니다.
- 댓글이 없을 때 표시되는 emptyLabel을 추가했습니다.
<img src = "https://github.com/SLTDV/Choice-iOS/assets/80827042/df362492-4adc-44ab-ac1c-11fb080dc50b" width= 300/>
<img src = "https://github.com/SLTDV/Choice-iOS/assets/80827042/02126302-3478-4596-a50f-0383a1686cde" width = 300/>
<img src = "https://github.com/SLTDV/Choice-iOS/assets/80827042/45baf2f3-1727-4106-a103-0078f4f99dda" width = 300 />
