### PR TITLE
전화번호 입력 페이지 컴포넌트 분리

### DIFF
--- a/Projects/App/Sources/Present/Auth/SignIn/ViewController/SignInViewController.swift
+++ b/Projects/App/Sources/Present/Auth/SignIn/ViewController/SignInViewController.swift
@@ -25,6 +25,12 @@ final class SignInViewController: BaseVC<SignInViewModel> {
         $0.isSecureTextEntry = true
     }
     
+    private let findPasswordButton = UIButton().then {
+        $0.setTitle("비밀번호를 잊어버리셨나요?", for: .normal)
+        $0.setTitleColor(UIColor.gray, for: .normal)
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 12, weight: .regular)
+    }
+    
     private lazy var signInButton = UIButton().then {
         $0.setTitle("로그인", for: .normal)
         $0.backgroundColor = .black
@@ -77,8 +83,11 @@ final class SignInViewController: BaseVC<SignInViewModel> {
     }
     
     override func addView() {
-        view.addSubviews(titleImageView, subTitleLabel, inputPhoneNumberTextField, inputPasswordTextField,
-                         signInButton, divideLineButton, pushSignUpButton, warningLabel)
+        view.addSubviews(
+            titleImageView, subTitleLabel,
+            inputPhoneNumberTextField, inputPasswordTextField,
+            findPasswordButton, signInButton, divideLineButton,
+            pushSignUpButton, warningLabel)
     }
     
     override func setLayout() {
@@ -102,6 +111,11 @@ final class SignInViewController: BaseVC<SignInViewModel> {
             $0.top.equalTo(inputPhoneNumberTextField.snp.bottom).offset(14)
             $0.leading.trailing.equalToSuperview().inset(26)
             $0.height.equalTo(58)
+        }
+        
+        findPasswordButton.snp.makeConstraints {
+            $0.top.equalTo(inputPasswordTextField.snp.bottom).offset(7)
+            $0.trailing.equalTo(inputPasswordTextField.snp.trailing)
         }
         
         signInButton.snp.makeConstraints {

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPassword/Component/inputPassword.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPassword/Component/inputPassword.swift
@@ -1,0 +1,9 @@
+//
+//  inputPassword.swift
+//  Choice
+//
+//  Created by 민도현 on 2023/06/08.
+//  Copyright © 2023 dohyeon. All rights reserved.
+//
+
+import Foundation

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/inputPhoneNumber.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/inputPhoneNumber.swift
@@ -1,0 +1,125 @@
+import UIKit
+import Shared
+
+class inputphoneNumberComponent: UIView {
+    private let emailLabel = UILabel().then {
+        $0.text = "전화번호"
+        $0.font = .systemFont(ofSize: 16, weight: .bold)
+    }
+    
+    private let inputPhoneNumberTextfield = BoxTextField().then {
+        $0.placeholder = "전화번호 입력"
+        $0.keyboardType = .numberPad
+    }
+    
+    private let requestAuthButton = UIButton().then {
+        $0.setTitle("인증 요청", for: .normal)
+        $0.isEnabled = false
+        $0.titleLabel?.font = .systemFont(ofSize: 14, weight: .semibold)
+        $0.backgroundColor = SharedAsset.grayVoteButton.color
+        $0.layer.cornerRadius = 8
+    }
+    
+    private let authNumberTextfield = BoxTextField().then {
+        $0.placeholder = "인증번호 입력"
+        $0.keyboardType = .numberPad
+        $0.isHidden = true
+    }
+    
+    private let countLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.textColor = .black
+    }
+    
+    private let resendLabel = UILabel().then {
+        $0.text = "인증번호가 오지 않나요?"
+        $0.font = .systemFont(ofSize: 12, weight: .medium)
+        $0.textColor = .gray
+        $0.isHidden = true
+    }
+    
+    private let resendButton = UIButton().then {
+        $0.setTitle("재요청", for: .normal)
+        $0.titleLabel?.font = .systemFont(ofSize: 13, weight: .semibold)
+        $0.setTitleColor(.black, for: .normal)
+        $0.isHidden = true
+    }
+    
+    private lazy var nextButton = UIButton().then {
+        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
+        $0.setTitle("다음", for: .normal)
+        $0.isEnabled = false
+        $0.backgroundColor = SharedAsset.grayVoteButton.color
+        $0.layer.cornerRadius = 8
+    }
+    
+    private let warningLabel = WarningLabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func addView() {
+        self.addSubviews(emailLabel,inputPhoneNumberTextfield, requestAuthButton,
+                         authNumberTextfield, warningLabel, nextButton,
+                         resendLabel, resendButton)
+        authNumberTextfield.addSubview(countLabel)
+    }
+    
+    func setLayout() {
+        emailLabel.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide).offset(70)
+            $0.leading.equalToSuperview().inset(26)
+        }
+        
+        inputPhoneNumberTextfield.snp.makeConstraints {
+            $0.top.equalTo(emailLabel.snp.bottom).offset(25)
+            $0.leading.equalToSuperview().inset(26)
+            $0.trailing.equalTo(requestAuthButton.snp.leading).offset(-10)
+            $0.height.equalTo(58)
+        }
+        
+        requestAuthButton.snp.makeConstraints {
+            $0.top.equalTo(inputPhoneNumberTextfield.snp.top)
+            $0.trailing.equalToSuperview().inset(26)
+            $0.width.equalTo(inputPhoneNumberTextfield.snp.width).multipliedBy(0.4)
+            $0.height.equalTo(58)
+        }
+        
+        authNumberTextfield.snp.makeConstraints {
+            $0.top.equalTo(inputPhoneNumberTextfield.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(26)
+            $0.height.equalTo(58)
+        }
+        
+        countLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(25)
+        }
+        
+        resendLabel.snp.makeConstraints {
+            $0.centerY.equalTo(resendButton)
+            $0.centerX.equalToSuperview().offset(-20)
+        }
+        
+        resendButton.snp.makeConstraints {
+            $0.top.equalTo(authNumberTextfield.snp.bottom).offset(15)
+            $0.leading.equalTo(resendLabel.snp.trailing).offset(8)
+        }
+        
+        warningLabel.snp.makeConstraints {
+            $0.leading.equalTo(nextButton.snp.leading)
+            $0.bottom.equalTo(nextButton.snp.top).offset(-12)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.bottom.equalTo(self.safeAreaInsets.bottom).inset(40)
+            $0.leading.trailing.equalToSuperview().inset(26)
+            $0.height.equalTo(58)
+        }
+    }
+}

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/inputPhoneNumber.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/inputPhoneNumber.swift
@@ -6,7 +6,7 @@ import RxCocoa
 protocol PhoneNumberComponentProtocol: AnyObject {
     func nextButtonDidTap()
     func requestAuthButtonDidTap(phoneNumber: String)
-    func resendButtonDidTap()
+    func resendButtonDidTap(phoneNumber: String)
 }
 
 class InputphoneNumberComponent: UIView {
@@ -180,6 +180,16 @@ class InputphoneNumberComponent: UIView {
             .withLatestFrom(phoneNumberObservable)
             .bind(with: self) { owner, inputPhoneNumber in
                 owner.delegate?.requestAuthButtonDidTap(phoneNumber: inputPhoneNumber)
+            }.disposed(by: disposeBag)
+    }
+    
+    private func resendButtonDidTap() {
+        let phoneNumberObservable = inputPhoneNumberTextfield.rx.text.orEmpty
+        
+        resendButton.rx.tap
+            .withLatestFrom(phoneNumberObservable)
+            .bind(with: self) { owner, inputPhoneNumber in
+                owner.delegate?.resendButtonDidTap(phoneNumber: inputPhoneNumber)
             }.disposed(by: disposeBag)
     }
 }

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/inputPhoneNumber.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/inputPhoneNumber.swift
@@ -16,7 +16,7 @@ class InputphoneNumberComponent: UIView {
     
     let warningLabel = WarningLabel()
     
-    let emailLabel = UILabel().then {
+    private let phoneNumberLabel = UILabel().then {
         $0.text = "전화번호"
         $0.font = .systemFont(ofSize: 16, weight: .bold)
     }
@@ -66,7 +66,7 @@ class InputphoneNumberComponent: UIView {
         $0.backgroundColor = SharedAsset.grayVoteButton.color
         $0.layer.cornerRadius = 8
     }
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -114,20 +114,20 @@ class InputphoneNumberComponent: UIView {
     }
     
     func addView() {
-        self.addSubviews(emailLabel,inputPhoneNumberTextfield, requestAuthButton,
+        self.addSubviews(phoneNumberLabel,inputPhoneNumberTextfield, requestAuthButton,
                          authNumberTextfield, warningLabel, nextButton,
                          resendLabel, resendButton)
         authNumberTextfield.addSubview(countLabel)
     }
     
     func setLayout() {
-        emailLabel.snp.makeConstraints {
+        phoneNumberLabel.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide).offset(70)
             $0.leading.equalToSuperview().inset(26)
         }
         
         inputPhoneNumberTextfield.snp.makeConstraints {
-            $0.top.equalTo(emailLabel.snp.bottom).offset(25)
+            $0.top.equalTo(phoneNumberLabel.snp.bottom).offset(25)
             $0.leading.equalToSuperview().inset(26)
             $0.trailing.equalTo(requestAuthButton.snp.leading).offset(-10)
             $0.height.equalTo(58)

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/ViewController/RegistrationPhoneNumberViewController.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/ViewController/RegistrationPhoneNumberViewController.swift
@@ -3,94 +3,19 @@ import RxSwift
 import RxCocoa
 import Shared
 
-final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumberViewModel> {
+final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumberViewModel>, PhoneNumberComponentProtocol {
     private let disposeBag = DisposeBag()
     
     private var isValidAuth = true
     
     private lazy var restoreFrameYValue = 0.0
     
-    private let phoneNumberLabel = UILabel().then {
-        $0.text = "전화번호"
-        $0.font = .systemFont(ofSize: 16, weight: .bold)
-    }
-    
-    private let inputPhoneNumberTextfield = BoxTextField().then {
-        $0.placeholder = "전화번호 입력"
-        $0.keyboardType = .numberPad
-    }
-    
-    private let requestAuthButton = UIButton().then {
-        $0.setTitle("인증 요청", for: .normal)
-        $0.isEnabled = false
-        $0.titleLabel?.font = .systemFont(ofSize: 14, weight: .semibold)
-        $0.backgroundColor = SharedAsset.grayVoteButton.color
-        $0.layer.cornerRadius = 8
-    }
-    
-    private let authNumberTextfield = BoxTextField().then {
-        $0.placeholder = "인증번호 입력"
-        $0.keyboardType = .numberPad
-        $0.isHidden = true
-    }
-    
-    private let countLabel = UILabel().then {
-        $0.textAlignment = .center
-        $0.textColor = .black
-    }
-    
-    private let resendLabel = UILabel().then {
-        $0.text = "인증번호가 오지 않나요?"
-        $0.font = .systemFont(ofSize: 12, weight: .medium)
-        $0.textColor = .gray
-        $0.isHidden = true
-    }
-    
-    private let resendButton = UIButton().then {
-        $0.setTitle("재요청", for: .normal)
-        $0.titleLabel?.font = .systemFont(ofSize: 13, weight: .semibold)
-        $0.setTitleColor(.black, for: .normal)
-        $0.isHidden = true
-    }
-    
-    private lazy var nextButton = UIButton().then {
-        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
-        $0.setTitle("다음", for: .normal)
-        $0.isEnabled = false
-        $0.backgroundColor = SharedAsset.grayVoteButton.color
-        $0.layer.cornerRadius = 8
-    }
-    
-    private let warningLabel = WarningLabel()
-    
-    private let component = inputphoneNumberComponent(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
-    
-    private func nextButtonDidTap() {
-        nextButton.rx.tap
-            .bind(with: self) { owner, _ in
-                LoadingIndicator.showLoading(text: "")
-                owner.checkAuthCode()
-            }.disposed(by: disposeBag)
-    }
-    
-    private func checkAuthCode() {
-        guard let phoneNumber = inputPhoneNumberTextfield.text else { return }
-        guard let authCode = authNumberTextfield.text else { return }
-        
-        self.viewModel.requestAuthNumberConfirmation(phoneNumber: phoneNumber, authCode: authCode) { [weak self] isVaild in
-            if isVaild {
-                self?.viewModel.pushRegistrationPasswordVC(phoneNumber: phoneNumber)
-            } else {
-                self?.warningLabel.show(warning: "*인증번호가 일치하지 않습니다")
-            }
-            LoadingIndicator.hideLoading()
-        }
-    }
+    private let component = InputphoneNumberComponent()
     
     private func bindUI() {
         let maxLength = 4
         
-        authNumberTextfield.rx.text.orEmpty
+        component.authNumberTextfield.rx.text.orEmpty
             .map { text -> (Bool, String) in
                 let isValid = (text.count == maxLength)
                 let truncatedText = String(text.prefix(maxLength))
@@ -98,81 +23,17 @@ final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumbe
             }
             .bind(with: self, onNext: { owner, result in
                 let (isValid, text) = result
-                owner.nextButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
-                owner.nextButton.isEnabled = isValid
-                owner.authNumberTextfield.text = text
+                owner.component.nextButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
+                owner.component.nextButton.isEnabled = isValid
+                owner.component.authNumberTextfield.text = text
             }).disposed(by: disposeBag)
-            
-        inputPhoneNumberTextfield.rx.text.orEmpty
+        
+        component.inputPhoneNumberTextfield.rx.text.orEmpty
             .map { $0.count == 11 }
             .bind(with: self) { owner, isValid in
-                owner.requestAuthButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
-                owner.requestAuthButton.isEnabled = isValid
-            }.disposed(by: disposeBag)
-    }
-    
-    private func requestAuthButtonDidTap() {
-        let phoneNumberObservable = inputPhoneNumberTextfield.rx.text.orEmpty
-        
-        requestAuthButton.rx.tap
-            .withLatestFrom(phoneNumberObservable)
-            .bind(with: self) { owner, inputPhoneNumber in
-                LoadingIndicator.showLoading(text: "")
-                
-                guard inputPhoneNumber.hasPrefix("010") else {
-                    owner.warningLabel.show(warning: "*전화번호 형식이 올바르지 않아요.")
-                    LoadingIndicator.hideLoading()
-                    return
-                }
-                
-                owner.viewModel.requestAuthNumber(phoneNumber: inputPhoneNumber) { isValid in
-                    if isValid {
-                        owner.setupPossibleBackgroundTimer()
-                        
-                        owner.authNumberTextfield.isHidden = false
-                        owner.resendLabel.isHidden = false
-                        owner.resendButton.isHidden = false
-                        
-                        owner.requestAuthButton.backgroundColor = SharedAsset.grayVoteButton.color
-                        owner.requestAuthButton.isEnabled = false
-                        
-                        owner.inputPhoneNumberTextfield.isUserInteractionEnabled = false
-                        owner.inputPhoneNumberTextfield.textColor = .placeholderText
-                        owner.warningLabel.hide()
-                    } else {
-                        owner.warningLabel.show(warning: "*이미 인증된 전화번호입니다")
-                    }
-                    
-                    LoadingIndicator.hideLoading()
-                }
-                owner.view.endEditing(true)
-            }.disposed(by: disposeBag)
-    }
-    
-    private func resendButtonDidTap() {
-        let phoneNumberObservable = inputPhoneNumberTextfield.rx.text.orEmpty
-        
-        resendButton.rx.tap
-            .withLatestFrom(phoneNumberObservable)
-            .bind(with: self) { owner, inputPhoneNumber in
-                LoadingIndicator.showLoading(text: "")
-                
-                guard owner.isValidAuth else {
-                    owner.warningLabel.show(warning: "*3분 후에 다시 시도해주세요")
-                    LoadingIndicator.hideLoading()
-                    return
-                }
-                
-                owner.viewModel.requestAuthNumber(phoneNumber: inputPhoneNumber) { isValid in
-                    if isValid {
-                        owner.setupPossibleBackgroundTimer()
-                        owner.warningLabel.hide()
-                    } else {
-                        owner.warningLabel.show(warning: "*이미 인증된 전화번호입니다")
-                    }
-                    
-                    LoadingIndicator.hideLoading()
-                }
+                print(isValid)
+                owner.component.requestAuthButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
+                owner.component.requestAuthButton.isEnabled = isValid
             }.disposed(by: disposeBag)
     }
     
@@ -187,10 +48,10 @@ final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumbe
             .bind(with: self) { owner, remainingSeconds in
                 let minutes = remainingSeconds / 60
                 let seconds = remainingSeconds % 60
-                owner.countLabel.text = String(format: "%02d:%02d", minutes, seconds)
+                owner.component.countLabel.text = String(format: "%02d:%02d", minutes, seconds)
                 
                 if remainingSeconds == 0 {
-                    owner.countLabel.text = "00:00"
+                    owner.component.countLabel.text = "00:00"
                     owner.isValidAuth = true
                 }
             }.disposed(by: disposeBag)
@@ -202,76 +63,103 @@ final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumbe
     
     override func configureVC() {
         restoreFrameYValue = self.view.frame.origin.y
-        nextButtonDidTap()
-        resendButtonDidTap()
-        requestAuthButtonDidTap()
         
         bindUI()
+        component.delegate = self
         
         navigationItem.title = "회원가입"
     }
     
     override func addView() {
-        view.addSubviews(phoneNumberLabel,inputPhoneNumberTextfield, requestAuthButton,
-                         authNumberTextfield, warningLabel, nextButton,
-                         resendLabel, resendButton, component)
-        
-        authNumberTextfield.addSubview(countLabel)
+        view.addSubviews(component)
     }
     
     override func setLayout() {
-//        component.snp.makeConstraints {
-//            $0.edges.equalToSuperview()
-//        }
-        phoneNumberLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(70)
-            $0.leading.equalToSuperview().inset(26)
+        component.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+
+extension RegistrationPhoneNumberViewController {
+    func nextButtonDidTap() {
+        LoadingIndicator.showLoading(text: "")
+        checkAuthCode()
+    }
+    
+    func requestAuthButtonDidTap(phoneNumber: String) {
+        LoadingIndicator.showLoading(text: "")
+        
+        guard phoneNumber.hasPrefix("010") else {
+            component.warningLabel.show(warning: "*전화번호 형식이 올바르지 않아요.")
+            LoadingIndicator.hideLoading()
+            return
         }
         
-        inputPhoneNumberTextfield.snp.makeConstraints {
-            $0.top.equalTo(phoneNumberLabel.snp.bottom).offset(25)
-            $0.leading.equalToSuperview().inset(26)
-            $0.trailing.equalTo(requestAuthButton.snp.leading).offset(-10)
-            $0.height.equalTo(58)
+        viewModel.requestAuthNumber(phoneNumber: phoneNumber) { [weak self] isValid in
+            if isValid {
+                self?.setupPossibleBackgroundTimer()
+                
+                self?.component.authNumberTextfield.isHidden = false
+                self?.component.resendLabel.isHidden = false
+                self?.component.resendButton.isHidden = false
+                
+                self?.component.requestAuthButton.backgroundColor = SharedAsset.grayVoteButton.color
+                self?.component.requestAuthButton.isEnabled = false
+                
+                self?.component.inputPhoneNumberTextfield.isUserInteractionEnabled = false
+                self?.component.inputPhoneNumberTextfield.textColor = .placeholderText
+                self?.component.warningLabel.hide()
+            } else {
+                self?.component.warningLabel.show(warning: "*이미 인증된 전화번호입니다")
+            }
+            
+            LoadingIndicator.hideLoading()
         }
+        view.endEditing(true)
+    }
+    
+    func resendButtonDidTap() {
+        let phoneNumberObservable = component.inputPhoneNumberTextfield.rx.text.orEmpty
         
-        requestAuthButton.snp.makeConstraints {
-            $0.top.equalTo(inputPhoneNumberTextfield.snp.top)
-            $0.trailing.equalToSuperview().inset(26)
-            $0.width.equalTo(inputPhoneNumberTextfield.snp.width).multipliedBy(0.4)
-            $0.height.equalTo(58)
-        }
+        component.resendButton.rx.tap
+            .withLatestFrom(phoneNumberObservable)
+            .bind(with: self) { owner, inputPhoneNumber in
+                LoadingIndicator.showLoading(text: "")
+                print(inputPhoneNumber)
+                
+                guard owner.isValidAuth else {
+                    owner.component.warningLabel.show(warning: "*3분 후에 다시 시도해주세요")
+                    LoadingIndicator.hideLoading()
+                    return
+                }
+                
+                owner.viewModel.requestAuthNumber(phoneNumber: inputPhoneNumber) { isValid in
+                    print("request!!@#")
+                    if isValid {
+                        owner.setupPossibleBackgroundTimer()
+                        owner.component.warningLabel.hide()
+                    } else {
+                        owner.component.warningLabel.show(warning: "*이미 인증된 전화번호입니다")
+                    }
+                    
+                    LoadingIndicator.hideLoading()
+                }
+            }.disposed(by: disposeBag)
+    }
+    
+    private func checkAuthCode() {
+        guard let phoneNumber = component.inputPhoneNumberTextfield.text else { return }
+        guard let authCode = component.authNumberTextfield.text else { return }
         
-        authNumberTextfield.snp.makeConstraints {
-            $0.top.equalTo(inputPhoneNumberTextfield.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(26)
-            $0.height.equalTo(58)
-        }
-        
-        countLabel.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(25)
-        }
-        
-        resendLabel.snp.makeConstraints {
-            $0.centerY.equalTo(resendButton)
-            $0.centerX.equalToSuperview().offset(-20)
-        }
-        
-        resendButton.snp.makeConstraints {
-            $0.top.equalTo(authNumberTextfield.snp.bottom).offset(15)
-            $0.leading.equalTo(resendLabel.snp.trailing).offset(8)
-        }
-        
-        warningLabel.snp.makeConstraints {
-            $0.leading.equalTo(nextButton.snp.leading)
-            $0.bottom.equalTo(nextButton.snp.top).offset(-12)
-        }
-        
-        nextButton.snp.makeConstraints {
-            $0.bottom.equalTo(view.safeAreaInsets.bottom).inset(40)
-            $0.leading.trailing.equalToSuperview().inset(26)
-            $0.height.equalTo(58)
+        self.viewModel.requestAuthNumberConfirmation(phoneNumber: phoneNumber, authCode: authCode) { [weak self] isVaild in
+            if isVaild {
+                self?.viewModel.pushRegistrationPasswordVC(phoneNumber: phoneNumber)
+            } else {
+                self?.component.warningLabel.show(warning: "*인증번호가 일치하지 않습니다")
+            }
+            LoadingIndicator.hideLoading()
         }
     }
 }

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/ViewController/RegistrationPhoneNumberViewController.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/ViewController/RegistrationPhoneNumberViewController.swift
@@ -10,7 +10,7 @@ final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumbe
     
     private lazy var restoreFrameYValue = 0.0
     
-    private let emailLabel = UILabel().then {
+    private let phoneNumberLabel = UILabel().then {
         $0.text = "전화번호"
         $0.font = .systemFont(ofSize: 16, weight: .bold)
     }
@@ -62,6 +62,8 @@ final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumbe
     }
     
     private let warningLabel = WarningLabel()
+    
+    private let component = inputphoneNumberComponent(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
     
     private func nextButtonDidTap() {
         nextButton.rx.tap
@@ -210,21 +212,24 @@ final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumbe
     }
     
     override func addView() {
-        view.addSubviews(emailLabel,inputPhoneNumberTextfield, requestAuthButton,
+        view.addSubviews(phoneNumberLabel,inputPhoneNumberTextfield, requestAuthButton,
                          authNumberTextfield, warningLabel, nextButton,
-                         resendLabel, resendButton)
+                         resendLabel, resendButton, component)
         
         authNumberTextfield.addSubview(countLabel)
     }
     
     override func setLayout() {
-        emailLabel.snp.makeConstraints {
+//        component.snp.makeConstraints {
+//            $0.edges.equalToSuperview()
+//        }
+        phoneNumberLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(70)
             $0.leading.equalToSuperview().inset(26)
         }
         
         inputPhoneNumberTextfield.snp.makeConstraints {
-            $0.top.equalTo(emailLabel.snp.bottom).offset(25)
+            $0.top.equalTo(phoneNumberLabel.snp.bottom).offset(25)
             $0.leading.equalToSuperview().inset(26)
             $0.trailing.equalTo(requestAuthButton.snp.leading).offset(-10)
             $0.height.equalTo(58)

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/ViewController/RegistrationPhoneNumberViewController.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/ViewController/RegistrationPhoneNumberViewController.swift
@@ -136,7 +136,6 @@ extension RegistrationPhoneNumberViewController {
                 }
                 
                 owner.viewModel.requestAuthNumber(phoneNumber: inputPhoneNumber) { isValid in
-                    print("request!!@#")
                     if isValid {
                         owner.setupPossibleBackgroundTimer()
                         owner.component.warningLabel.hide()

--- a/Projects/App/Sources/Present/Main/Home/ViewController/HomeViewController.swift
+++ b/Projects/App/Sources/Present/Main/Home/ViewController/HomeViewController.swift
@@ -72,6 +72,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
                 cell.setType(type: .home)
                 cell.configure(with: data)
                 cell.postVoteButtonDelegate = self
+                cell.disposeBag = self.disposeBag
                 cell.separatorInset = UIEdgeInsets.zero
             }.disposed(by: disposeBag)
         


### PR DESCRIPTION
## 제목
전화번호 입력 페이지의 요소를 컴포넌트로 분리했습니다. (비밀번호 찾기에서 또 사용됨.)

## 작업 내용
Button 클릭 시 발생하는 액션은 delegate 패턴을 통해 ```RegistrationPhoneNumberViewController``` 에서 구현했습니다.

<img src="https://github.com/SLTDV/Choice-iOS/assets/81687906/7ef4e58f-8512-4f9e-ac21-f4bfc2756d9a" width="200">

> ```RegistrationPasswordViewController``` 도 분리할 예정이라 폴더와 파일을 만들어뒀습니다.!