### PR TITLE
비빌번호 입력 페이지 컴포넌트로 분리 및 리펙토링

### DIFF
--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPassword/Component/InputPasswordComponent.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPassword/Component/InputPasswordComponent.swift
@@ -1,0 +1,109 @@
+import UIKit
+import Shared
+import RxSwift
+import RxCocoa
+
+protocol InputPasswordComponentProtocol: AnyObject {
+    func nextButtonDidTap()
+}
+
+class InputPasswordComponent: UIView {
+    weak var delegate: InputPasswordComponentProtocol?
+    
+    private let disposeBag = DisposeBag()
+    
+    private let passwordLabel = UILabel().then {
+        $0.text = "비밀번호"
+        $0.font = .systemFont(ofSize: 16, weight: .bold)
+    }
+    
+    let inputPasswordTextField = BoxTextField(type: .secureTextField).then {
+        $0.placeholder = "8~16자리 영문, 숫자, 특수문자 조합"
+        $0.isSecureTextEntry = true
+    }
+    
+    let checkPasswordTextField = BoxTextField(type: .secureTextField).then {
+        $0.placeholder = "비밀번호 재입력"
+        $0.isSecureTextEntry = true
+    }
+    
+    lazy var nextButton = UIButton().then {
+        $0.setTitle("다음", for: .normal)
+        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
+        $0.isEnabled = false
+        $0.backgroundColor = SharedAsset.grayVoteButton.color
+        $0.layer.cornerRadius = 8
+    }
+    
+    let warningLabel = WarningLabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addView()
+        setLayout()
+        bindRx()
+        bindUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func addView() {
+        self.addSubviews(passwordLabel, inputPasswordTextField,
+                         checkPasswordTextField, warningLabel, nextButton)
+    }
+    
+    func setLayout() {
+        passwordLabel.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide).offset(70)
+            $0.leading.equalToSuperview().inset(26)
+        }
+        
+        inputPasswordTextField.snp.makeConstraints {
+            $0.top.equalTo(passwordLabel.snp.bottom).offset(25)
+            $0.leading.trailing.equalToSuperview().inset(26)
+            $0.height.equalTo(58)
+        }
+        
+        checkPasswordTextField.snp.makeConstraints {
+            $0.top.equalTo(inputPasswordTextField.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(26)
+            $0.height.equalTo(58)
+        }
+        
+        warningLabel.snp.makeConstraints {
+            $0.leading.equalTo(nextButton.snp.leading)
+            $0.bottom.equalTo(nextButton.snp.top).offset(-12)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.bottom.equalTo(self.safeAreaInsets.bottom).inset(40)
+            $0.leading.trailing.equalToSuperview().inset(26)
+            $0.height.equalTo(58)
+        }
+    }
+    
+    private func bindUI() {
+        let passwordObservable = inputPasswordTextField.rx.text.orEmpty
+        let checkPasswordObservable = checkPasswordTextField.rx.text.orEmpty
+        
+        Observable.combineLatest(
+            passwordObservable,
+            checkPasswordObservable,
+            resultSelector: { s1, s2 in (8...16).contains(s1.count) && (8...16).contains(s2.count) }
+        )
+        .bind(with: self) { owner, isValid in
+            owner.nextButton.isEnabled = isValid
+            owner.nextButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
+        }.disposed(by: disposeBag)
+    }
+    
+    private func bindRx() {
+        nextButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.delegate?.nextButtonDidTap()
+            }.disposed(by: disposeBag)
+    }
+}

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPassword/Component/inputPassword.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPassword/Component/inputPassword.swift
@@ -1,9 +1,0 @@
-//
-//  inputPassword.swift
-//  Choice
-//
-//  Created by 민도현 on 2023/06/08.
-//  Copyright © 2023 dohyeon. All rights reserved.
-//
-
-import Foundation

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPassword/ViewController/RegistrationPasswordViewController.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPassword/ViewController/RegistrationPasswordViewController.swift
@@ -3,113 +3,46 @@ import RxSwift
 import RxCocoa
 import Shared
 
-final class RegistrationPasswordViewController: BaseVC<RegistrationPasswordViewModel> {
-    private let disposeBag = DisposeBag()
+final class RegistrationPasswordViewController: BaseVC<RegistrationPasswordViewModel>, InputPasswordComponentProtocol {
     
-    private let passwordLabel = UILabel().then {
-        $0.text = "비밀번호"
-        $0.font = .systemFont(ofSize: 16, weight: .bold)
-    }
-    
-    private let inputPasswordTextField = BoxTextField(type: .secureTextField).then {
-        $0.placeholder = "8~16자리 영문, 숫자, 특수문자 조합"
-        $0.isSecureTextEntry = true
-    }
-    
-    private let checkPasswordTextField = BoxTextField(type: .secureTextField).then {
-        $0.placeholder = "비밀번호 재입력"
-        $0.isSecureTextEntry = true
-    }
-    
-    private lazy var nextButton = UIButton().then {
-        $0.setTitle("다음", for: .normal)
-        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
-        $0.isEnabled = false
-        $0.backgroundColor = SharedAsset.grayVoteButton.color
-        $0.layer.cornerRadius = 8
-    }
-    
-    private let warningLabel = WarningLabel()
-    
-    private func bindUI() {
-        let passwordObservable = inputPasswordTextField.rx.text.orEmpty
-        let checkPasswordObservable = checkPasswordTextField.rx.text.orEmpty
-        
-        Observable.combineLatest(
-            passwordObservable,
-            checkPasswordObservable,
-            resultSelector: { s1, s2 in (8...16).contains(s1.count) && (8...16).contains(s2.count) }
-        )
-        .bind(with: self) { owner, isValid in
-            owner.nextButton.isEnabled = isValid
-            owner.nextButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
-        }.disposed(by: disposeBag)
-    }
+    private let component = InputPasswordComponent()
     
     private func checkPassword() {
-        guard let password = inputPasswordTextField.text else { return }
-        guard let checkPassword = checkPasswordTextField.text else { return }
+        guard let password = component.inputPasswordTextField.text else { return }
+        guard let checkPassword = component.checkPasswordTextField.text else { return }
         
         if password.elementsEqual(checkPassword) {
             if self.viewModel.isValidPassword(password: password){
                 self.viewModel.pushUserProfileInfoVC(password: password)
             } else {
-                self.warningLabel.show(warning: "*비밀번호 형식이 올바르지 않아요.")
+                self.component.warningLabel.show(warning: "*비밀번호 형식이 올바르지 않아요.")
             }
         } else {
-            self.warningLabel.show(warning: "*비밀번호가 일치하지 않아요.")
+            self.component.warningLabel.show(warning: "*비밀번호가 일치하지 않아요.")
         }
-        
         LoadingIndicator.hideLoading()
     }
     
-    private func nextButtonDidTap() {
-        nextButton.rx.tap
-            .bind(with: self) { owner, _ in
-                LoadingIndicator.showLoading(text: "")
-                owner.checkPassword()
-            }.disposed(by: disposeBag)
-    }
-    
     override func configureVC() {
-        bindUI()
-        nextButtonDidTap()
-        
         navigationItem.title = "회원가입"
+        
+        component.delegate = self
     }
     
     override func addView() {
-        view.addSubviews(passwordLabel, inputPasswordTextField,
-                         checkPasswordTextField, warningLabel, nextButton)
+        view.addSubview(component)
     }
     
     override func setLayout() {
-        passwordLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(70)
-            $0.leading.equalToSuperview().inset(26)
+        component.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
-        
-        inputPasswordTextField.snp.makeConstraints {
-            $0.top.equalTo(passwordLabel.snp.bottom).offset(25)
-            $0.leading.trailing.equalToSuperview().inset(26)
-            $0.height.equalTo(58)
-        }
-        
-        checkPasswordTextField.snp.makeConstraints {
-            $0.top.equalTo(inputPasswordTextField.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(26)
-            $0.height.equalTo(58)
-        }
-        
-        warningLabel.snp.makeConstraints {
-            $0.leading.equalTo(nextButton.snp.leading)
-            $0.bottom.equalTo(nextButton.snp.top).offset(-12)
-        }
-        
-        nextButton.snp.makeConstraints {
-            $0.bottom.equalTo(view.safeAreaInsets.bottom).inset(40)
-            $0.leading.trailing.equalToSuperview().inset(26)
-            $0.height.equalTo(58)
-        }
+    }
+}
+
+extension RegistrationPasswordViewController {
+    func nextButtonDidTap() {
+        LoadingIndicator.showLoading(text: "")
+        checkPassword()
     }
 }

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/InputphoneNumberComponent.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/InputphoneNumberComponent.swift
@@ -3,14 +3,14 @@ import Shared
 import RxSwift
 import RxCocoa
 
-protocol PhoneNumberComponentProtocol: AnyObject {
+protocol InputPhoneNumberComponentProtocol: AnyObject {
     func nextButtonDidTap()
     func requestAuthButtonDidTap(phoneNumber: String)
     func resendButtonDidTap(phoneNumber: String)
 }
 
 class InputphoneNumberComponent: UIView {
-    weak var delegate: PhoneNumberComponentProtocol?
+    weak var delegate: InputPhoneNumberComponentProtocol?
     
     private let disposeBag = DisposeBag()
     
@@ -61,7 +61,7 @@ class InputphoneNumberComponent: UIView {
         $0.isHidden = true
     }
     
-    let nextButton = UIButton().then {
+    private let nextButton = UIButton().then {
         $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .semibold)
         $0.setTitle("다음", for: .normal)
         $0.isEnabled = false
@@ -210,7 +210,6 @@ class InputphoneNumberComponent: UIView {
         inputPhoneNumberTextfield.rx.text.orEmpty
             .map { $0.count == 11 }
             .bind(with: self) { owner, isValid in
-                print(isValid)
                 owner.requestAuthButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
                 owner.requestAuthButton.isEnabled = isValid
             }.disposed(by: disposeBag)

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/inputPhoneNumber.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/Component/inputPhoneNumber.swift
@@ -14,6 +14,8 @@ class InputphoneNumberComponent: UIView {
     
     private let disposeBag = DisposeBag()
     
+    var isValidAuth = true
+    
     let warningLabel = WarningLabel()
     
     private let phoneNumberLabel = UILabel().then {
@@ -73,6 +75,7 @@ class InputphoneNumberComponent: UIView {
         addView()
         setLayout()
         bindRx()
+        bindUI()
     }
     
     required init?(coder: NSCoder) {
@@ -86,31 +89,6 @@ class InputphoneNumberComponent: UIView {
             }.disposed(by: disposeBag)
         
         requestAuthButtonDidTap()
-    }
-    
-    private func bindUI() {
-        let maxLength = 4
-        
-        authNumberTextfield.rx.text.orEmpty
-            .map { text -> (Bool, String) in
-                let isValid = (text.count == maxLength)
-                let truncatedText = String(text.prefix(maxLength))
-                return (isValid, truncatedText)
-            }
-            .bind(with: self, onNext: { owner, result in
-                let (isValid, text) = result
-                owner.nextButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
-                owner.nextButton.isEnabled = isValid
-                owner.authNumberTextfield.text = text
-            }).disposed(by: disposeBag)
-        
-        inputPhoneNumberTextfield.rx.text.orEmpty
-            .map { $0.count == 11 }
-            .bind(with: self) { owner, isValid in
-                print(isValid)
-                owner.requestAuthButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
-                owner.requestAuthButton.isEnabled = isValid
-            }.disposed(by: disposeBag)
     }
     
     func addView() {
@@ -190,6 +168,51 @@ class InputphoneNumberComponent: UIView {
             .withLatestFrom(phoneNumberObservable)
             .bind(with: self) { owner, inputPhoneNumber in
                 owner.delegate?.resendButtonDidTap(phoneNumber: inputPhoneNumber)
+            }.disposed(by: disposeBag)
+    }
+    
+    func setupPossibleBackgroundTimer() {
+        let count = 180
+        
+        isValidAuth = false
+        
+        Observable<Int>.interval(.seconds(1), scheduler: MainScheduler.instance)
+            .take(count+1)
+            .map { count - $0 }
+            .bind(with: self) { owner, remainingSeconds in
+                let minutes = remainingSeconds / 60
+                let seconds = remainingSeconds % 60
+                owner.countLabel.text = String(format: "%02d:%02d", minutes, seconds)
+                
+                if remainingSeconds == 0 {
+                    owner.countLabel.text = "00:00"
+                    owner.isValidAuth = true
+                }
+            }.disposed(by: disposeBag)
+    }
+    
+    private func bindUI() {
+        let maxLength = 4
+        
+        authNumberTextfield.rx.text.orEmpty
+            .map { text -> (Bool, String) in
+                let isValid = (text.count == maxLength)
+                let truncatedText = String(text.prefix(maxLength))
+                return (isValid, truncatedText)
+            }
+            .bind(with: self, onNext: { owner, result in
+                let (isValid, text) = result
+                owner.nextButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
+                owner.nextButton.isEnabled = isValid
+                owner.authNumberTextfield.text = text
+            }).disposed(by: disposeBag)
+        
+        inputPhoneNumberTextfield.rx.text.orEmpty
+            .map { $0.count == 11 }
+            .bind(with: self) { owner, isValid in
+                print(isValid)
+                owner.requestAuthButton.backgroundColor = isValid ? .black : SharedAsset.grayVoteButton.color
+                owner.requestAuthButton.isEnabled = isValid
             }.disposed(by: disposeBag)
     }
 }

--- a/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/ViewController/RegistrationPhoneNumberViewController.swift
+++ b/Projects/App/Sources/Present/Auth/SignUp/RegistrationPhoneNum/ViewController/RegistrationPhoneNumberViewController.swift
@@ -3,7 +3,7 @@ import RxSwift
 import RxCocoa
 import Shared
 
-final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumberViewModel>, PhoneNumberComponentProtocol {
+final class RegistrationPhoneNumberViewController: BaseVC<RegistrationPhoneNumberViewModel>, InputPhoneNumberComponentProtocol {
     private let disposeBag = DisposeBag()
 
     private lazy var restoreFrameYValue = 0.0


### PR DESCRIPTION
## 제목
비빌번호 입력 페이지 컴포넌트로 분리하고 전화번호 입력 컴포넌트를 리펙토링했습니다.

## 작업 내용
- isValidAuth 변수를 전화번호 입력 컴포넌트로 분리했습니다.
- 비밀번호 입력 페이지를 컴포넌트로 분리했습니다. (비밀번호 찾기에서 사용됨.)
<img src="https://github.com/SLTDV/Choice-iOS/assets/81687906/11c3e27e-50aa-40fd-bc97-e44d91a51150" width="200">
