### PR TITLE
정렬버튼 타이틀 이슈 해결

### DIFF
--- a/Projects/App/Sources/Present/Main/Home/ViewController/HomeViewController.swift
+++ b/Projects/App/Sources/Present/Main/Home/ViewController/HomeViewController.swift
@@ -165,7 +165,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol, PostVo
     
     @objc private func handleRefreshControl(_ sender: UIRefreshControl) {
         self.postData.accept([])
-        sortTableViewData(type: .findNewestPostData)
+        sortTableViewData(type: sortType)
         DispatchQueue.main.async {
             self.postTableView.reloadData()
             self.postTableView.refreshControl?.endRefreshing()


### PR DESCRIPTION
## 이런 문제가 있었습니다.
home 에서 ```refresh```시 최신순으로 정렬하도록 했었는데, 
**게시물을 인기순으로 정렬하고 ```refresh```해도 최신순으로 정렬되지만 정렬 버튼의 title 은 인기순으로 되어있기 때문에 혼란이 있었습니다.**
ex) 인기순으로 정렬 후 refresh -> 최신순으로 refresh(title은 아직 인기순)

## 이렇게 해결했습니다.
```refresh``` 시 현재 정렬했던 상태로 하도록 변경했습니다.
ex) 인기순으로 정렬 후 refresh -> 인기순으로 refresh(title이 인기순으로 변경)
