### PR TITLE
[Refactor] DetailPostVM - API 호출 함수 Observable 로 변경

### DIFF
--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -182,7 +182,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private func presentReportPostAlert() {
-        AlertHelper.showAlert(
+        AlertHelper.shared.showAlert(
             title: "게시물 신고",
             message: """
                     해당 게시물이 불쾌감을 줬다면 신고해주세요.
@@ -195,7 +195,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private func presentBlockUserAlert() {
-        AlertHelper.showAlert(
+        AlertHelper.shared.showAlert(
             title: "차단하기",
             message: """
                      해당 사용자를 차단할 수 있습니다.

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -661,11 +661,11 @@ extension DetailPostViewController {
         viewModel.requestToCreateComment(idx: model.value.idx, content: content) { [weak self] result in
             switch result {
             case .success(()):
-                self?.viewModel.requestCommentData(idx: (self?.model.value.idx)!)
+                self?.commentData.accept([])
+                self?.loadMoreComments()
                 self?.commentTableView.reloadRows(at: [IndexPath(row: 0, section: 0)], with: .automatic)
                 self?.enterCommentTextView.text = nil
                 self?.enterCommentTextView.resignFirstResponder()
-                self?.commentData.accept([])
                 self?.isLastPage = false
                 self?.setDefaultSubmitButton()
             case .failure(let error):

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -331,22 +331,15 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             guard let self = self else { return }
             
             self.commentTableView.performBatchUpdates(nil, completion: nil)
-            self.viewModel.requestCommentData(idx: self.model.value.idx) { [weak self] result in
-                guard let self = self else { return }
-                
-                self.commentTableView.tableFooterView = nil
-                
-                switch result {
-                case .success(let size):
+            viewModel.requestCommentData(idx: self.model.value.idx)
+                .bind(with: self) { owner, size in
+                    owner.commentTableView.tableFooterView = nil
                     if size != 10 {
                         self.isLastPage = true
                     } else {
                         self.commentTableView.reloadData()
                     }
-                case .failure(let error):
-                    print("comment pagination error = \(error.localizedDescription)")
-                }
-            }
+                }.disposed(by: disposeBag)
         }
     }
     

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -230,37 +230,34 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         let alert = UIAlertController(title: "", message: "", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .cancel))
         
-        viewModel.requestToReportPost(postIdx: self.model.value.idx) { result in
-            switch result {
-            case .success:
+        viewModel.requestToReportPost(postIdx: self.model.value.idx)
+            .subscribe(onNext: {
                 alert.title = "완료"
                 alert.message = "신고가 접수되었습니다"
-            case .failure:
+            },onError: {_ in
                 alert.title = "실패"
                 alert.message = "이미 신고한 게시물입니다"
-            }
-            self.present(alert, animated: true)
-        }
+            }, onCompleted: {
+                self.present(alert, animated: true)
+            }).disposed(by: disposeBag)
     }
     
     private func blockUserAlert() {
         let alert = UIAlertController(title: "", message: "", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .cancel))
         
-        viewModel.requestToBlockUser(postIdx: self.model.value.idx) { [weak self] result in
-            switch result {
-            case .success:
+        viewModel.requestToBlockUser(postIdx: self.model.value.idx)
+            .subscribe(onNext: {
                 alert.title = "완료"
                 alert.message = "차단이 완료되었습니다."
-                self?.viewModel.popToRootVC()
+                self.viewModel.popToRootVC()
                 NotificationCenter.default.post(name: NSNotification.Name("BlockButtonPressed"), object: nil)
-            case .failure:
+            }, onError: { _ in
                 alert.title = "실패"
                 alert.message = "차단이 완료되었습니다."
-            }
-            
-            self?.present(alert, animated: true)
-        }
+            }, onCompleted: {
+                self.present(alert, animated: true)
+            }).disposed(by: disposeBag)
     }
     
     private func keyboardUp(_ notification: Notification) {

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -230,11 +230,12 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         let alert = UIAlertController(title: "", message: "", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .cancel))
         
-        viewModel.requestToReportPost(postIdx: self.model.value.idx) { isVaild in
-            if isVaild {
+        viewModel.requestToReportPost(postIdx: self.model.value.idx) { result in
+            switch result {
+            case .success:
                 alert.title = "완료"
                 alert.message = "신고가 접수되었습니다"
-            } else {
+            case .failure:
                 alert.title = "실패"
                 alert.message = "이미 신고한 게시물입니다"
             }
@@ -248,12 +249,12 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         
         viewModel.requestToBlockUser(postIdx: self.model.value.idx) { [weak self] result in
             switch result {
-            case true:
+            case .success:
                 alert.title = "완료"
                 alert.message = "차단이 완료되었습니다."
                 self?.viewModel.popToRootVC()
                 NotificationCenter.default.post(name: NSNotification.Name("BlockButtonPressed"), object: nil)
-            case false:
+            case .failure:
                 alert.title = "실패"
                 alert.message = "차단이 완료되었습니다."
             }

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -17,20 +17,19 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     var writerImageStringData = PublishSubject<String?>()
     var isMineData = false
     var commentData = BehaviorRelay<[CommentList]>(value: [])
-    private var model = BehaviorRelay<PostList>(
-        value: PostList(
-            idx: 0,
-            firstImageUrl: "",
-            secondImageUrl: "",
-            title: "",
-            content: "",
-            firstVotingOption: "",
-            secondVotingOption: "",
-            firstVotingCount: 0,
-            secondVotingCount: 0,
-            votingState: 0,
-            participants: 0,
-            commentCount: 0)
+    private var model = BehaviorRelay<PostList>(value: PostList(
+        idx: 0,
+        firstImageUrl: "",
+        secondImageUrl: "",
+        title: "",
+        content: "",
+        firstVotingOption: "",
+        secondVotingOption: "",
+        firstVotingCount: 0,
+        secondVotingCount: 0,
+        votingState: 0,
+        participants: 0,
+        commentCount: 0)
     )
     var isLastPage = false
     var type: ViewControllerType?
@@ -163,7 +162,10 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         $0.numberOfLines = 0
     }
     
-    private lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapMethod(_:)))
+    private lazy var tapGestureRecognizer = UITapGestureRecognizer(
+        target: self,
+        action: #selector(tapMethod(_:))
+    )
     
     init(viewModel: DetailPostViewModel, model: PostList, type: ViewControllerType) {
         super.init(viewModel: viewModel)
@@ -189,7 +191,8 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                     신고가 누적되면 필터링을 통해 게시물이
                     삭제될 수 있습니다. (중복 불가능)
                     """,
-            actionTitle: "신고", onConfirm: {
+            actionTitle: "신고",
+            onConfirm: {
                 self.reportPostAlert()
             }, vc: self)
     }
@@ -209,19 +212,19 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     func setKeyboard() {
-        let keyboardWillShow = NotificationCenter.default.rx.notification(UIResponder.keyboardWillShowNotification)
-        let keyboardWillHide =
-        NotificationCenter.default.rx.notification(UIResponder.keyboardWillHideNotification)
+        let notiCenter = NotificationCenter.default.rx
+        let keyboardWillShow = notiCenter.notification(UIResponder.keyboardWillShowNotification)
+        let keyboardWillHide = notiCenter.notification(UIResponder.keyboardWillHideNotification)
         
         keyboardWillShow
-            .asDriver(onErrorRecover: { _ in .never()})
-            .drive(with: self) { owner, noti in
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, noti in
                 owner.keyboardUp(noti)
             }.disposed(by: disposeBag)
         
         keyboardWillHide
-            .asDriver(onErrorRecover: { _ in .never()})
-            .drive(with: self) { owner, noti in
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
                 owner.keyboardDown()
             }.disposed(by: disposeBag)
     }
@@ -261,7 +264,9 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private func keyboardUp(_ notification: Notification) {
-        if let keyboardFrame:CGRect = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+        if let keyboardFrame: CGRect = notification.userInfo?[
+            UIResponder.keyboardFrameEndUserInfoKey
+        ] as? CGRect {
             UIView.animate(withDuration: 0.3, animations: {
                 self.view.frame.origin.y -= keyboardFrame.size.height
             })
@@ -310,9 +315,8 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     
     private func updateEmptyLabelLayout() {
         setOptionLayout()
-        
-        let comments = commentData.value
-        if comments.isEmpty && isLastPage {
+
+        if commentData.value.isEmpty && isLastPage {
             emptyLabel.frame = CGRect(x: 0, y: 15, width: commentTableView.bounds.width, height: 100)
             commentTableView.tableHeaderView = emptyLabel
             commentTableView.separatorStyle = .none

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -324,20 +324,18 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     
     private func loadMoreComments() {
         commentTableView.tableFooterView = createSpinnerFooter()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.3) { [weak self] in
-            guard let self = self else { return }
-            
-            self.commentTableView.performBatchUpdates(nil, completion: nil)
-            viewModel.requestCommentData(idx: self.model.value.idx)
-                .bind(with: self) { owner, size in
-                    owner.commentTableView.tableFooterView = nil
-                    if size != 10 {
-                        self.isLastPage = true
-                    } else {
-                        self.commentTableView.reloadData()
-                    }
-                }.disposed(by: disposeBag)
-        }
+        
+        self.commentTableView.performBatchUpdates(nil, completion: nil)
+        viewModel.requestCommentData(idx: self.model.value.idx)
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, size in
+                owner.commentTableView.tableFooterView = nil
+                if size != 10 {
+                    self.isLastPage = true
+                } else {
+                    self.commentTableView.reloadData()
+                }
+            }.disposed(by: disposeBag)
     }
     
     private func bindUI() {
@@ -700,6 +698,7 @@ extension DetailPostViewController: UITableViewDelegate {
                         with: .automatic
                     )
                 }
+                LoadingIndicator.hideLoading()
             }.disposed(by: self.disposeBag)
         })
         deleteContextual.image = UIImage(systemName: "trash")

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -237,7 +237,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             },onError: {_ in
                 alert.title = "실패"
                 alert.message = "이미 신고한 게시물입니다"
-            }, onCompleted: {
+            }, onDisposed: {
                 self.present(alert, animated: true)
             }).disposed(by: disposeBag)
     }
@@ -255,7 +255,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             }, onError: { _ in
                 alert.title = "실패"
                 alert.message = "차단이 완료되었습니다."
-            }, onCompleted: {
+            }, onDisposed: {
                 self.present(alert, animated: true)
             }).disposed(by: disposeBag)
     }

--- a/Projects/App/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Projects/App/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -139,8 +139,9 @@ final class DetailPostViewModel: BaseViewModel {
                     observer.onNext(())
                     observer.onCompleted()
                 case .failure(let error):
-                    observer.onError(error)
                     print("Error - ReportPost - \(error.localizedDescription)")
+                    observer.onError(error)
+                    observer.onCompleted()
                 }
             }
             return Disposables.create()
@@ -162,8 +163,9 @@ final class DetailPostViewModel: BaseViewModel {
                     observer.onNext(())
                     observer.onCompleted()
                 case .failure(let error):
-                    observer.onError(error)
                     print("Erorr - BlockUser = \(error.localizedDescription)")
+                    observer.onError(error)
+                    observer.onCompleted()
                 }
             }
             return Disposables.create()

--- a/Projects/App/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Projects/App/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -93,7 +93,7 @@ final class DetailPostViewModel: BaseViewModel {
         }
     }
     
-    func requestToDeleteComment(postIdx: Int, commentIdx: Int, completion: @escaping (Result<Void, Error>) -> ()) {
+    func requestToDeleteComment(postIdx: Int, commentIdx: Int, completion: @escaping (Result<Void, Error>) -> Void) {
         let url = APIConstants.deleteCommentURL + "\(postIdx)/" + "\(commentIdx)"
         AF.request(url,
                    method: .delete,
@@ -110,7 +110,7 @@ final class DetailPostViewModel: BaseViewModel {
         }
     }
     
-    func requestToReportPost(postIdx: Int, completion: @escaping (Bool) -> Void) {
+    func requestToReportPost(postIdx: Int, completion: @escaping (Result<Void, Error>) -> Void) {
         let url = APIConstants.reportPostURL + "\(postIdx)"
         AF.request(url,
                    method: .post,
@@ -120,14 +120,14 @@ final class DetailPostViewModel: BaseViewModel {
         .responseData(emptyResponseCodes: [200, 201, 204]) { response in
             switch response.result {
             case .success:
-                completion(true)
-            case .failure(_):
-                completion(false)
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }
     
-    func requestToBlockUser(postIdx: Int, completion: @escaping (Bool) -> Void) {
+    func requestToBlockUser(postIdx: Int, completion: @escaping (Result<Void, Error>) -> Void) {
         let url = APIConstants.blockUserURL + "\(postIdx)"
         AF.request(url,
                    method: .post,
@@ -137,10 +137,10 @@ final class DetailPostViewModel: BaseViewModel {
         .responseData(emptyResponseCodes: [200, 201, 204]) { response in
             switch response.result {
             case .success:
-                completion(true)
+                completion(.success(()))
             case .failure(let error):
                 print("Erorr - BlockUser = \(error.localizedDescription)")
-                completion(false)
+                completion(.failure(error))
             }
         }
     }

--- a/Projects/App/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Projects/App/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -137,11 +137,9 @@ final class DetailPostViewModel: BaseViewModel {
                 switch response.result {
                 case .success:
                     observer.onNext(())
-                    observer.onCompleted()
                 case .failure(let error):
                     print("Error - ReportPost - \(error.localizedDescription)")
                     observer.onError(error)
-                    observer.onCompleted()
                 }
             }
             return Disposables.create()
@@ -161,11 +159,9 @@ final class DetailPostViewModel: BaseViewModel {
                 switch response.result {
                 case .success:
                     observer.onNext(())
-                    observer.onCompleted()
                 case .failure(let error):
                     print("Erorr - BlockUser = \(error.localizedDescription)")
                     observer.onError(error)
-                    observer.onCompleted()
                 }
             }
             return Disposables.create()

--- a/Projects/App/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
+++ b/Projects/App/Sources/Present/Detail/ViewModel/DetailPostViewModel.swift
@@ -95,6 +95,7 @@ final class DetailPostViewModel: BaseViewModel {
                 case .success:
                     observer.onNext(())
                 case .failure(let error):
+                    print("Error - CreateComment - \(error.localizedDescription)")
                     observer.onError(error)
                 }
             }
@@ -116,45 +117,56 @@ final class DetailPostViewModel: BaseViewModel {
                 case .success:
                     observer.onNext(())
                 case .failure(let error):
-                    observer.onError(error)
+                    print("Error - DeleteComment - \(error.localizedDescription)")
                 }
             }
             return Disposables.create()
         }
     }
     
-    func requestToReportPost(postIdx: Int, completion: @escaping (Result<Void, Error>) -> Void) {
+    func requestToReportPost(postIdx: Int) -> Observable<Void> {
         let url = APIConstants.reportPostURL + "\(postIdx)"
-        AF.request(url,
-                   method: .post,
-                   encoding: URLEncoding.queryString,
-                   interceptor: JwtRequestInterceptor(jwtStore: container))
-        .validate()
-        .responseData(emptyResponseCodes: [200, 201, 204]) { response in
-            switch response.result {
-            case .success:
-                completion(.success(()))
-            case .failure(let error):
-                completion(.failure(error))
+        
+        return Observable.create { (observer) -> Disposable in
+            AF.request(url,
+                       method: .post,
+                       encoding: URLEncoding.queryString,
+                       interceptor: JwtRequestInterceptor(jwtStore: self.container))
+            .validate()
+            .responseData(emptyResponseCodes: [200, 201, 204]) { response in
+                switch response.result {
+                case .success:
+                    observer.onNext(())
+                    observer.onCompleted()
+                case .failure(let error):
+                    observer.onError(error)
+                    print("Error - ReportPost - \(error.localizedDescription)")
+                }
             }
+            return Disposables.create()
         }
     }
     
-    func requestToBlockUser(postIdx: Int, completion: @escaping (Result<Void, Error>) -> Void) {
+    func requestToBlockUser(postIdx: Int) -> Observable<Void> {
         let url = APIConstants.blockUserURL + "\(postIdx)"
-        AF.request(url,
-                   method: .post,
-                   encoding: URLEncoding.queryString,
-                   interceptor: JwtRequestInterceptor(jwtStore: container))
-        .validate()
-        .responseData(emptyResponseCodes: [200, 201, 204]) { response in
-            switch response.result {
-            case .success:
-                completion(.success(()))
-            case .failure(let error):
-                print("Erorr - BlockUser = \(error.localizedDescription)")
-                completion(.failure(error))
+        
+        return Observable.create { observer -> Disposable in
+            AF.request(url,
+                       method: .post,
+                       encoding: URLEncoding.queryString,
+                       interceptor: JwtRequestInterceptor(jwtStore: self.container))
+            .validate()
+            .responseData(emptyResponseCodes: [200, 201, 204]) { response in
+                switch response.result {
+                case .success:
+                    observer.onNext(())
+                    observer.onCompleted()
+                case .failure(let error):
+                    observer.onError(error)
+                    print("Erorr - BlockUser = \(error.localizedDescription)")
+                }
             }
+            return Disposables.create()
         }
     }
     

--- a/Projects/Shared/Sources/Util/Class/AlertHelper.swift
+++ b/Projects/Shared/Sources/Util/Class/AlertHelper.swift
@@ -4,7 +4,7 @@ public protocol CustomAlertProtocol {
     typealias Action = () -> ()
     
     static var shared: CustomAlertProtocol { get }
-    static func showAlert(title: String, message: String, actionTitle: String, onConfirm: @escaping Action, vc viewController: UIViewController)
+    func showAlert(title: String, message: String, actionTitle: String, onConfirm: @escaping Action, vc viewController: UIViewController)
 }
 
 public class AlertHelper: CustomAlertProtocol {
@@ -12,7 +12,7 @@ public class AlertHelper: CustomAlertProtocol {
     
     private init() {}
     
-    public static func showAlert(title: String, message: String, actionTitle: String, onConfirm: @escaping Action, vc viewController: UIViewController) {
+    public func showAlert(title: String, message: String, actionTitle: String, onConfirm: @escaping Action, vc viewController: UIViewController) {
         let alertControl = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let eventAction = UIAlertAction(title: actionTitle, style: .destructive) { _ in
             onConfirm()


### PR DESCRIPTION
## 제목
DetailPostViewModel 의 API 호출 함수들을 Observable로 변경했습니다.

## 작업 내용
기존 @escaping closure으로 Bool 이나 Reuslt값을 ViewController에서 쓸 수 있도록 했는데, 이는 일관성이 없고, 불필요하다고 생각해 Observable 로 변경했습니다. 이를 통해 이제 API 성공, 실패에 따라 비동기적으로 처리할 수 있습니다.