### PR TITLE
로그인 성공 시 LoadingIndicator 사라지지 않던 문제 해결

### DIFF
--- a/Projects/App/Sources/Present/Auth/SignIn/ViewController/SignInViewController.swift
+++ b/Projects/App/Sources/Present/Auth/SignIn/ViewController/SignInViewController.swift
@@ -71,7 +71,9 @@ final class SignInViewController: BaseVC<SignInViewModel> {
                     phoneNumber: phoneNumber,
                     password: password,
                     fcmToken: fcmToken
-                )).subscribe(onError: { [weak self] _ in
+                )).subscribe(onNext: {
+                    LoadingIndicator.hideLoading()
+                }, onError: { [weak self] _ in
                     LoadingIndicator.hideLoading()
                     self?.showSignInError()
                     UserDefaults.standard.removeObject(forKey: "fcmToken")


### PR DESCRIPTION
## 제목
로그인 성공 시 LoadingIndicator 가 사라지지 않던 문제를 해결했습니다.

## 작업 내용
기존 Error 일 때만 subscribe 해 LoadingIndicator 를 hide 했습니다. -> 이때문에 로그인이 성공 시 LoadingIndicator 가 hide 되지 않는 문제가 발생했습니다.
<img src="https://github.com/SLTDV/Choice-iOS/assets/81687906/79c85a4e-5fb1-4e9f-b4a2-57a104327458" width="200">

### 해결
onNext 이벤트도 받아, LoadingIndicator를 hide 하도록 변경했습니다.