### PR TITLE
Fix - 로그인 성공 시 LoadingIndicator hide

### DIFF
--- a/Projects/App/Resources/LaunchScreen.storyboard
+++ b/Projects/App/Resources/LaunchScreen.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,18 +18,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="HomeLogo" translatesAutoresizingMaskIntoConstraints="NO" id="s6m-AS-XeD">
-                                <rect key="frame" x="130" y="415" width="133" height="33"/>
+                                <rect key="frame" x="130" y="409.66666666666669" width="133" height="33"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="133" id="rvv-OG-61K"/>
-                                    <constraint firstAttribute="height" constant="33" id="sdp-W7-3f7"/>
+                                    <constraint firstAttribute="height" constant="33" id="1Vc-64-0ix"/>
+                                    <constraint firstAttribute="width" constant="133" id="Pyi-TX-RbK"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="선택의 고민을 한 번에" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rUu-4K-5zV">
-                                <rect key="frame" x="177" y="448" width="86" height="12"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="86" id="cEC-mV-ExL"/>
-                                    <constraint firstAttribute="height" constant="12" id="wtl-wR-gsf"/>
-                                </constraints>
+                                <rect key="frame" x="177" y="446.66666666666669" width="86" height="12"/>
                                 <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="10"/>
                                 <color key="textColor" red="0.42745098039215684" green="0.42745098039215684" blue="0.42745098039215684" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -39,11 +35,10 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="s6m-AS-XeD" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="130" id="9Qp-EP-Lm1"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="rUu-4K-5zV" secondAttribute="bottom" constant="358" id="Crg-Gq-Dk7"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="rUu-4K-5zV" secondAttribute="trailing" constant="130" id="L1T-mK-oJF"/>
-                            <constraint firstItem="rUu-4K-5zV" firstAttribute="top" secondItem="s6m-AS-XeD" secondAttribute="bottom" id="Ss3-sY-ISE"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="s6m-AS-XeD" secondAttribute="trailing" constant="130" id="mHe-MZ-sXT"/>
+                            <constraint firstItem="s6m-AS-XeD" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="BD1-i9-fEc"/>
+                            <constraint firstItem="rUu-4K-5zV" firstAttribute="top" secondItem="s6m-AS-XeD" secondAttribute="bottom" constant="4" id="FQt-Bk-H4u"/>
+                            <constraint firstItem="s6m-AS-XeD" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="GpX-M4-EJh"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="rUu-4K-5zV" secondAttribute="trailing" constant="130" id="Qh5-p2-hLo"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -53,7 +48,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="HomeLogo" width="99" height="33"/>
+        <image name="HomeLogo" width="96" height="30"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Projects/App/Sources/App/Application/AppDelegate.swift
+++ b/Projects/App/Sources/App/Application/AppDelegate.swift
@@ -21,6 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         FirebaseApp.configure()
         
         Messaging.messaging().delegate = self
+        UNUserNotificationCenter.current().delegate = self
         
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in
             DispatchQueue.main.async {
@@ -78,8 +79,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 extension AppDelegate: MessagingDelegate {
-    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+    func messaging(
+        _ messaging: Messaging,
+        didReceiveRegistrationToken fcmToken: String?
+    ) {
         print("fcmToken = \(fcmToken)")
         UserDefaults.standard.set(fcmToken, forKey: "fcmToken")
+    }
+}
+
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let userInfo = response.notification.request.content.userInfo
+        
+        if let action = userInfo["action"] as? String {
+            print("action1! = \(action)")
+        }
     }
 }

--- a/Projects/App/Sources/App/Application/AppDelegate.swift
+++ b/Projects/App/Sources/App/Application/AppDelegate.swift
@@ -21,7 +21,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         FirebaseApp.configure()
         
         Messaging.messaging().delegate = self
-        UNUserNotificationCenter.current().delegate = self
         
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in
             DispatchQueue.main.async {
@@ -85,19 +84,5 @@ extension AppDelegate: MessagingDelegate {
     ) {
         print("fcmToken = \(fcmToken)")
         UserDefaults.standard.set(fcmToken, forKey: "fcmToken")
-    }
-}
-
-
-extension AppDelegate: UNUserNotificationCenterDelegate {
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse
-    ) async {
-        let userInfo = response.notification.request.content.userInfo
-        
-        if let action = userInfo["action"] as? String {
-            print("action1! = \(action)")
-        }
     }
 }

--- a/Projects/App/Sources/Present/Auth/SignIn/ViewController/SignInViewController.swift
+++ b/Projects/App/Sources/Present/Auth/SignIn/ViewController/SignInViewController.swift
@@ -71,7 +71,9 @@ final class SignInViewController: BaseVC<SignInViewModel> {
                     phoneNumber: phoneNumber,
                     password: password,
                     fcmToken: fcmToken
-                )).subscribe(onError: { [weak self] _ in
+                )).subscribe(onNext: {
+                    LoadingIndicator.hideLoading()
+                },onError: { [weak self] _ in
                     LoadingIndicator.hideLoading()
                     self?.showSignInError()
                     UserDefaults.standard.removeObject(forKey: "fcmToken")

--- a/Projects/App/Sources/Present/Auth/SignIn/ViewController/SignInViewController.swift
+++ b/Projects/App/Sources/Present/Auth/SignIn/ViewController/SignInViewController.swift
@@ -73,10 +73,10 @@ final class SignInViewController: BaseVC<SignInViewModel> {
                     fcmToken: fcmToken
                 )).subscribe(onNext: {
                     LoadingIndicator.hideLoading()
+                    UserDefaults.standard.removeObject(forKey: "fcmToken")
                 },onError: { [weak self] _ in
                     LoadingIndicator.hideLoading()
                     self?.showSignInError()
-                    UserDefaults.standard.removeObject(forKey: "fcmToken")
                 }).disposed(by: owner.disposeBag)
             }.disposed(by: disposeBag)
         

--- a/Projects/App/Sources/Present/Common/Cell/PostCell/PostCell.swift
+++ b/Projects/App/Sources/Present/Common/Cell/PostCell/PostCell.swift
@@ -333,15 +333,17 @@ final class PostCell: UITableViewCell {
     // MARK: - prepare
     
     override func prepareForReuse() {
+        super.prepareForReuse()
         firstPostImageView.image = nil
         secondPostImageView.image = nil
+        disposeBag = DisposeBag()
     }
     
     func configure(with model: PostList) {
         self.model.accept(model)
         
         self.model
-            .filter { _ in self.hasFailedImageLoading == false }
+            .filter { [weak self] _ in self?.hasFailedImageLoading == false }
             .compactMap {
                 guard let firstUrl = URL(string: $0.firstImageUrl),
                       let secondUrl = URL(string: $0.secondImageUrl)

--- a/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
+++ b/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
@@ -172,7 +172,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol,
     @objc private func handleRefreshControl(_ sender: UIRefreshControl) {
         sortTableViewData(type: sortType)
         postData.accept([])
-//        postTableView.reloadData()
+        postTableView.reloadData()
         postTableView.refreshControl?.endRefreshing()
     }
     

--- a/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
+++ b/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
@@ -160,8 +160,8 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol,
                 LoadingIndicator.showLoading(text: "")
                 self?.sortTableViewData(type: action.type)
                 DispatchQueue.main.async {
-                    self?.postTableView.reloadData()
                     self?.postData.accept([])
+                    self?.postTableView.reloadData()
                     self?.dropdownButton.setTitle("\(action.title) ↓", for: .normal)
                 }
             }
@@ -172,7 +172,7 @@ final class HomeViewController: BaseVC<HomeViewModel>, PostItemsProtocol,
     @objc private func handleRefreshControl(_ sender: UIRefreshControl) {
         sortTableViewData(type: sortType)
         postData.accept([])
-        postTableView.reloadData()
+//        postTableView.reloadData()
         postTableView.refreshControl?.endRefreshing()
     }
     

--- a/Projects/App/Sources/Present/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/App/Sources/Present/Home/ViewModel/HomeViewModel.swift
@@ -46,9 +46,7 @@ final class HomeViewModel: BaseViewModel {
             case .success(let postData):
                 LoadingIndicator.hideLoading()
                 completion(.success(postData.size))
-                var relay = self?.delegate?.postData.value
-                relay?.append(contentsOf: postData.postList)
-                self?.delegate?.postData.accept(relay!)
+                self?.delegate?.postData.accept(postData.postList)
             case .failure(let error):
                 completion(.failure(error))
                 print("main error = \(error.localizedDescription)")

--- a/Projects/App/Sources/Present/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/App/Sources/Present/Home/ViewModel/HomeViewModel.swift
@@ -12,7 +12,7 @@ protocol PostItemsProtocol: AnyObject {
 
 final class HomeViewModel: BaseViewModel {
     weak var delegate: PostItemsProtocol?
-    private var disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
     var newestPostCurrentPage = -1
     var bestPostCurrentPage = -1
     private let container = AppDelegate.container.resolve(JwtStore.self)!
@@ -46,7 +46,9 @@ final class HomeViewModel: BaseViewModel {
             case .success(let postData):
                 LoadingIndicator.hideLoading()
                 completion(.success(postData.size))
-                self?.delegate?.postData.accept(postData.postList)
+                var relay = self?.delegate?.postData.value
+                relay?.append(contentsOf: postData.postList)
+                self?.delegate?.postData.accept(relay!)
             case .failure(let error):
                 completion(.failure(error))
                 print("main error = \(error.localizedDescription)")

--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -44,7 +44,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
-		<string>processing</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
## 제목
로그인 성공 시 LoadingIndicator가 hide되지 않던 문제를 해결했습니다.


## 작업 내용
기존 Error 일 때만 subscribe 의 onError를 통해 LoadingIndicator 를 hide 했습니다. -> 이때문에 로그인이 성공 시 LoadingIndicator 가 hide 되지 않는 문제가 발생했습니다.


<img src="https://github.com/SLTDV/Choice-iOS/assets/81687906/9ddfdf76-fad2-430a-8f7e-016017cdcba5" width="200">

- 아직 셀이 버벅거리는 문제가 있어 prepareForReuse 를 수정했습니다.
- PostCell 의 model bind 부분에서 메모리 릭이 발생할 것 같은 곳에 ```weak self``` 로 방지했습니다.

## 해결
onNext 이벤트도 받아, LoadingIndicator를 hide 하도록 변경했습니다.