### PR TITLE
[Reject] Delete Location Setting

### DIFF
--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -53,7 +53,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
-		<string>location</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
## 제목
앱스토어 reject 사유를 반영했습니다.

## 작업 내용
UIBackground Capability 에 불필요하게 ```Locaion updates```가 체크되어있었습니다.
지속적인 위치 업데이트가 필요한 기능이 없는데 해당 부분을 체크했던게 reject 사유였습니다. (실수로 추가했던 것 같습니다..)

![스크린샷 2023-09-21 오전 10 15 57](https://github.com/SLTDV/Choice-iOS/assets/81687906/330ff1af-3e4c-4c73-8445-e3317b1226ee)

App Store 안내에 따라 해당 부분을 Info에서 제거했습니다.
![스크린샷 2023-09-21 오전 10 17 53](https://github.com/SLTDV/Choice-iOS/assets/81687906/dbc2275c-2ea1-45db-ac4f-d9f090eaa492)
