### PR TITLE
[Refactor] NetworMonitor - 외부 인스턴스 생성 방지

### DIFF
--- a/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
+++ b/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
@@ -252,7 +252,7 @@ extension HomeViewController {
             vc: self)
     }
     
-    func showAlertOnNetworkDisConnect() {
+    func showAlertOnNetworkDisConnected() {
         AlertHelper.shared.showAlert(
             title: "네트워크 연결 실패!",
             message: "네트워크 연결에 실패했습니다. 앱을 다시 실행해주세요.",
@@ -265,7 +265,7 @@ extension HomeViewController {
             vc: self)
     }
     
-    func showAlertOnNetworkChange() {
+    func showAlertOnNetworkChanged() {
         AlertHelper.shared.showAlert(
             title: "네트워크 변경 감지!",
             message: "네트워크 변경이 감지되었습니다. 앱을 다시 실행해주세요.",

--- a/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
+++ b/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
@@ -14,6 +14,8 @@ public class NetworksStatus {
     
     public static let shared = NetworksStatus()
     
+    private init() {}
+    
     public func startMonitoring() {
         monitor.start(queue: DispatchQueue.global())
         monitor.pathUpdateHandler = { [weak self] path in

--- a/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
+++ b/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
@@ -1,6 +1,6 @@
 import Network
 
-public protocol NetworkConnectionHandlerProtocol: AnyObject {
+public protocol  : AnyObject {
     func showAlertOnNetworkDisConnected()
     func showAlertOnNetworkChanged()
 }

--- a/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
+++ b/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
@@ -1,6 +1,6 @@
 import Network
 
-public protocol  : AnyObject {
+public protocol NetworkConnectionHandlerProtocol: AnyObject {
     func showAlertOnNetworkDisConnected()
     func showAlertOnNetworkChanged()
 }

--- a/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
+++ b/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
@@ -1,9 +1,8 @@
 import Network
-//import UIKit
 
 public protocol NetworkConnectionHandlerProtocol: AnyObject {
-    func showAlertOnNetworkDisConnect()
-    func showAlertOnNetworkChange()
+    func showAlertOnNetworkDisConnected()
+    func showAlertOnNetworkChanged()
 }
 
 public class NetworksStatus {
@@ -36,7 +35,7 @@ public class NetworksStatus {
                 self.currentNWInterfaceType = .wiredEthernet
             }
         } else {
-            delegate?.showAlertOnNetworkDisConnect()
+            delegate?.showAlertOnNetworkDisConnected()
             return
         }
         
@@ -47,10 +46,10 @@ public class NetworksStatus {
         }
         
         if newStatus.status != .satisfied {
-            delegate?.showAlertOnNetworkDisConnect()
+            delegate?.showAlertOnNetworkDisConnected()
         } else {
             if previousNWInterfaceType != currentNWInterfaceType {
-                delegate?.showAlertOnNetworkChange()
+                delegate?.showAlertOnNetworkChanged()
             }
         }
         previousNWInterfaceType = currentNWInterfaceType

--- a/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
+++ b/Projects/Core/NetworksMonitor/Sources/NetworkStatus.swift
@@ -1,5 +1,5 @@
 import Network
-import UIKit
+//import UIKit
 
 public protocol NetworkConnectionHandlerProtocol: AnyObject {
     func showAlertOnNetworkDisConnect()


### PR DESCRIPTION
## 제목
NetworMonitor 모듈을 리펙토링 했습니다.

## 작업 내용
```NetworkConnectionHandlerProtocol``` 의 내부 함수 네이밍을 변경했습니다.
- ```showAlertOnNetworkDisConnect``` -> ```showAlertOnNetworkDisConnected```
- ```showAlertOnNetworkChange``` -> ```showAlertOnNetworkChanged```

### 이런 문제가 있었습니다.
현재 ```NetworksStatus``` 클래스를 싱글톤으로 다른 모듈에서 사용하고 있는데, 외부에서 인스턴스 생성이 가능했습니다.

### 이렇게 해결했습니다.
생성자를 private 접근 제어자를 통해 외부에서 인스턴스 생성이 불가능하도록 변경했습니다. 
