### PR TITLE
인스타 공유 이슈 해결

### DIFF
--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -195,8 +195,8 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                     ShareToInstagram.shareToInstaStories(detailPostView: owner.detailPostView, backgroundImage: backgroundImage) {
                         owner.presentFailedShareAlert()
                     }
+                    owner.detailPostView.setContentLabelNumberOfLines(lines: 0)
                 }
-                owner.detailPostView.setContentLabelNumberOfLines(lines: 0)
             }.disposed(by: disposeBag)
     }
     

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -191,8 +191,10 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
         sharePostButton.rx.tap
             .bind(with: self) { owner, _ in
                 owner.detailPostView.setContentLabelNumberOfLines(lines: 4)
-                ShareToInstagram.shareToInstaStories(detailPostView: owner.detailPostView, backgroundImage: backgroundImage) {
-                    owner.presentFailedShareAlert()
+                DispatchQueue.main.async {
+                    ShareToInstagram.shareToInstaStories(detailPostView: owner.detailPostView, backgroundImage: backgroundImage) {
+                        owner.presentFailedShareAlert()
+                    }
                 }
                 owner.detailPostView.setContentLabelNumberOfLines(lines: 0)
             }.disposed(by: disposeBag)


### PR DESCRIPTION
## 제목
인스타 공유 이슈 해결

## 작업 내용
내용이 긴 게시물은 인스타 스토리 공유를 할때 부적절한 위치에 아이템이 배치되는 이슈가 있었습니다.
-  DispatchQueue 를 사용한 비동기 처리로 해결하였습니다.

