### PR TITLE
showAlert함수 매개변수 기본값 설정

### DIFF
--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -195,7 +195,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                 self?.reportPostAlert()
             },
             cancelTitle: "취소",
-            cancelAction: nil,
             vc: self)
     }
     
@@ -212,7 +211,6 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                 self?.blockUserAlert()
             },
             cancelTitle: "취소",
-            cancelAction: nil,
             vc: self)
     }
     
@@ -222,10 +220,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
             message: """
                      Instagram이 설치되어 있지 않습니다.
                      """,
-            acceptTitle: nil,
-            acceptAction: nil,
             cancelTitle: "확인",
-            cancelAction: nil,
             vc: self)
     }
     

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -183,7 +183,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private func presentReportPostAlert() {
-        AlertHelper.shared.showAlert(
+        AlertHelper.shared.presentAlert(
             title: "게시물 신고",
             message: """
                     해당 게시물이 불쾌감을 줬다면 신고해주세요.
@@ -199,7 +199,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private func presentBlockUserAlert() {
-        AlertHelper.shared.showAlert(
+        AlertHelper.shared.presentAlert(
             title: "차단하기",
             message: """
                      해당 사용자를 차단할 수 있습니다.
@@ -215,7 +215,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
     }
     
     private func presentFailedShareAlert() {
-        AlertHelper.shared.showAlert(
+        AlertHelper.shared.presentAlert(
             title: "실패",
             message: """
                      Instagram이 설치되어 있지 않습니다.

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -191,8 +191,8 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                     삭제될 수 있습니다. (중복 불가능)
                     """,
             acceptTitle: "신고",
-            acceptAction: { [weak self] in
-                self?.reportPostAlert()
+            acceptAction: {
+                self.reportPostAlert()
             },
             cancelTitle: "취소",
             vc: self)
@@ -207,8 +207,8 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                      보이지 않습니다.
                      """,
             acceptTitle: "차단",
-            acceptAction: { [weak self] in
-                self?.blockUserAlert()
+            acceptAction: {
+                self.blockUserAlert()
             },
             cancelTitle: "취소",
             vc: self)

--- a/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
+++ b/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
@@ -242,7 +242,7 @@ extension HomeViewController {
     }
     
     func showAlertOnFailedImageLoading() {
-        AlertHelper.shared.showAlert(
+        AlertHelper.shared.presentAlert(
             title: "이미지 로딩 실패!",
             message: "네트워크 상태를 확인해주세요.",
             cancelTitle: "확인",
@@ -250,7 +250,7 @@ extension HomeViewController {
     }
     
     func showAlertOnNetworkDisConnected() {
-        AlertHelper.shared.showAlert(
+        AlertHelper.shared.presentAlert(
             title: "네트워크 연결 실패!",
             message: "네트워크 연결에 실패했습니다. 앱을 다시 실행해주세요.",
             cancelTitle: "확인",
@@ -261,7 +261,7 @@ extension HomeViewController {
     }
     
     func showAlertOnNetworkChanged() {
-        AlertHelper.shared.showAlert(
+        AlertHelper.shared.presentAlert(
             title: "네트워크 변경 감지!",
             message: "네트워크 변경이 감지되었습니다. 앱을 다시 실행해주세요.",
             cancelTitle: "확인",

--- a/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
+++ b/Projects/App/Sources/Present/Home/ViewController/HomeViewController.swift
@@ -245,10 +245,7 @@ extension HomeViewController {
         AlertHelper.shared.showAlert(
             title: "이미지 로딩 실패!",
             message: "네트워크 상태를 확인해주세요.",
-            acceptTitle: nil,
-            acceptAction: nil,
             cancelTitle: "확인",
-            cancelAction: nil,
             vc: self)
     }
     
@@ -256,8 +253,6 @@ extension HomeViewController {
         AlertHelper.shared.showAlert(
             title: "네트워크 연결 실패!",
             message: "네트워크 연결에 실패했습니다. 앱을 다시 실행해주세요.",
-            acceptTitle: nil,
-            acceptAction: nil,
             cancelTitle: "확인",
             cancelAction: {
                 AppCloseHandler.closedApp()
@@ -269,8 +264,6 @@ extension HomeViewController {
         AlertHelper.shared.showAlert(
             title: "네트워크 변경 감지!",
             message: "네트워크 변경이 감지되었습니다. 앱을 다시 실행해주세요.",
-            acceptTitle: nil,
-            acceptAction: nil,
             cancelTitle: "확인",
             cancelAction: {
                 AppCloseHandler.closedApp()

--- a/Projects/Core/DesignSystem/Sources/Util/Class/AlertHelper.swift
+++ b/Projects/Core/DesignSystem/Sources/Util/Class/AlertHelper.swift
@@ -3,7 +3,6 @@ import UIKit
 public protocol CustomAlertProtocol {
     typealias Action = () -> ()
     
-    static var shared: CustomAlertProtocol { get }
     func showAlert(
         title: String,
         message: String,
@@ -16,7 +15,7 @@ public protocol CustomAlertProtocol {
 }
 
 public class AlertHelper: CustomAlertProtocol {
-    public static let shared: CustomAlertProtocol = AlertHelper()
+    public static let shared: AlertHelper = AlertHelper()
     
     private init() {}
     

--- a/Projects/Core/DesignSystem/Sources/Util/Class/AlertHelper.swift
+++ b/Projects/Core/DesignSystem/Sources/Util/Class/AlertHelper.swift
@@ -3,7 +3,7 @@ import UIKit
 public protocol CustomAlertProtocol {
     typealias Action = () -> ()
     
-    func showAlert(
+    func presentAlert(
         title: String,
         message: String,
         acceptTitle: String?,
@@ -31,7 +31,7 @@ public class AlertHelper: CustomAlertProtocol {
         alertControl.addAction(action)
     }
     
-    public func showAlert(
+    public func presentAlert(
         title: String,
         message: String,
         acceptTitle: String? = "",

--- a/Projects/Core/DesignSystem/Sources/Util/Class/AlertHelper.swift
+++ b/Projects/Core/DesignSystem/Sources/Util/Class/AlertHelper.swift
@@ -4,34 +4,43 @@ public protocol CustomAlertProtocol {
     typealias Action = () -> ()
     
     static var shared: CustomAlertProtocol { get }
-    func showAlert(title: String,
-                   message: String,
-                   acceptTitle: String?,
-                   acceptAction: Action?,
-                   cancelTitle: String,
-                   cancelAction: Action?,
-                   vc viewController: UIViewController)
+    func showAlert(
+        title: String,
+        message: String,
+        acceptTitle: String?,
+        acceptAction: Action?,
+        cancelTitle: String,
+        cancelAction: Action?,
+        vc viewController: UIViewController
+    )
 }
 
 public class AlertHelper: CustomAlertProtocol {
-    public static var shared: CustomAlertProtocol = AlertHelper()
+    public static let shared: CustomAlertProtocol = AlertHelper()
     
     private init() {}
     
-    private func addAction(to alertControl: UIAlertController, title: String, style: UIAlertAction.Style, handler: Action?) {
+    private func addAction(
+        to alertControl: UIAlertController,
+        title: String,
+        style: UIAlertAction.Style,
+        handler: Action?
+    ) {
         let action = UIAlertAction(title: title, style: style) { _ in
             handler?()
         }
         alertControl.addAction(action)
     }
     
-    public func showAlert(title: String,
-                          message: String,
-                          acceptTitle: String?,
-                          acceptAction: Action?,
-                          cancelTitle: String,
-                          cancelAction: Action?,
-                          vc viewController: UIViewController) {
+    public func showAlert(
+        title: String,
+        message: String,
+        acceptTitle: String? = "",
+        acceptAction: Action? = nil,
+        cancelTitle: String,
+        cancelAction: Action? = nil,
+        vc viewController: UIViewController
+    ) {
         let alertControl = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
         if let actionTitle = acceptTitle, let acceptAction = acceptAction {


### PR DESCRIPTION
## 제목
showAlert함수에 매개변수 default 값을 적용해 호출 시 불필요한 인자의 기본값을 넘길 필요가 없습니다.
## 고민

 <img src="https://github.com/SLTDV/Choice-iOS/assets/81687906/8c301ef8-8b7e-4fee-b9ae-9397701605c1">


 <img src="https://github.com/SLTDV/Choice-iOS/assets/81687906/3590a3f5-84d2-4f02-9199-b70dc4dfe855">

- 현재 DetailVC에서 `showAlert` 를 호출할 때 `acceptAction` 에서 `weak self` 를 쓰고 있는데, 해당 부분이 순환참조 문제가 있을까요??
각각의 함수(reportPostAlert, blockUserAlert)에서 메모리가 해제되지 않는 경우가 없다면.. 굳이 `weak self` 를 쓸 필요가 없어보입니다.

- 추가로 showAlert함수의 vc 매개변수를 delegate로 네이밍 변경하는게 어떨까요? 역할이 delegate역할인 것 같아서 더 어울리는 것 같습니다.
> vc -> delegate
