### PR TITLE
[Refactor] Downsampling scale  (Image Quality)

### DIFF
--- a/Projects/App/Sources/Present/Common/Cell/PostCell/PostCell.swift
+++ b/Projects/App/Sources/Present/Common/Cell/PostCell/PostCell.swift
@@ -350,7 +350,7 @@ final class PostCell: UITableViewCell {
                     guard let image = try? await Downsampling.optimization(
                         imageAt: firstImageUrl,
                         to: owner.firstPostImageView.frame.size,
-                        scale: 2
+                        scale: UIScreen.main.scale
                     ) else {
                         owner.failedImageLoading()
                         return
@@ -362,7 +362,7 @@ final class PostCell: UITableViewCell {
                     guard let image = try? await Downsampling.optimization(
                         imageAt: secondImageUrl,
                         to: owner.secondPostImageView.frame.size,
-                        scale: 2
+                        scale: UIScreen.main.scale
                     ) else {
                         owner.failedImageLoading()
                         return

--- a/Projects/App/Sources/Present/Detail/View/DetailPostView.swift
+++ b/Projects/App/Sources/Present/Detail/View/DetailPostView.swift
@@ -128,7 +128,7 @@ final class DetailPostView: UIView {
             guard let image =  try? await Downsampling.optimization(
                 imageAt: firstImageUrl,
                 to: firstPostImageView.frame.size,
-                scale: 2
+                scale: UIScreen.main.scale
             ) else { return }
             
             firstPostImageView.image = image
@@ -138,7 +138,7 @@ final class DetailPostView: UIView {
             guard let image =  try? await Downsampling.optimization(
                 imageAt: secondImageUrl,
                 to: secondPostImageView.frame.size,
-                scale: 2
+                scale: UIScreen.main.scale
             ) else { return }
             
             secondPostImageView.image = image

--- a/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
+++ b/Projects/App/Sources/Present/Detail/ViewController/DetailPostViewController.swift
@@ -369,7 +369,7 @@ final class DetailPostViewController: BaseVC<DetailPostViewModel>, CommentDataPr
                     guard let image = try? await Downsampling.optimization(
                         imageAt: imageUrl,
                         to: owner.userImageView.frame.size,
-                        scale: 2
+                        scale: UIScreen.main.scale
                     ) else { return }
                     owner.userImageView.image = image
                 }

--- a/Projects/App/Sources/Present/Profile/ViewController/ProfileViewController.swift
+++ b/Projects/App/Sources/Present/Profile/ViewController/ProfileViewController.swift
@@ -124,7 +124,7 @@ final class ProfileViewController: BaseVC<ProfileViewModel>, ProfileDataProtocol
                     guard let image = try? await Downsampling.optimization(
                         imageAt: url,
                         to: owner.profileImageView.frame.size,
-                        scale: 2
+                        scale: UIScreen.main.scale
                     ) else { return }
                     owner.profileImageView.image = image
                 }

--- a/Projects/Core/DesignSystem/Sources/Util/Class/Downsampling.swift
+++ b/Projects/Core/DesignSystem/Sources/Util/Class/Downsampling.swift
@@ -37,7 +37,7 @@ public enum Downsampling {
         }
         
         let downsampledUIImage = UIImage(
-            data: UIImage(cgImage: downsampledIamge).jpegData(compressionQuality: 0.7)!
+            data: UIImage(cgImage: downsampledIamge).jpegData(compressionQuality: 1)!
         )
         
         imageCache.setObject(

--- a/Projects/Core/DesignSystem/Sources/Util/Class/Downsampling.swift
+++ b/Projects/Core/DesignSystem/Sources/Util/Class/Downsampling.swift
@@ -3,9 +3,11 @@ import UIKit
 public enum Downsampling {
     private static let imageCache = NSCache<NSURL, UIImage>()
     
-    public static func optimization(imageAt imageURL: URL,
-                                    to pointSize: CGSize,
-                                    scale: CGFloat) async throws -> UIImage? {
+    public static func optimization(
+        imageAt imageURL: URL,
+        to pointSize: CGSize,
+        scale: CGFloat
+    ) async throws -> UIImage? {
         // 이미지 캐시 확인
         if let cachedImage = imageCache.object(
             forKey: imageURL as NSURL


### PR DESCRIPTION
## 제목
Downsampling의 scale 크기를 변경하고 jepg 퀄리티 수치를 수정했습니다. 

## 작업 내용
- **Downsampling의 scale 크기를 기존 3에서 Screen scale로 변경했습니다.**
왜냐하면, 디스플레이 종류에 따라서 1point가 몇 개의 pixel로 이루어지는지 달라진다고 합니다. 
ex) iPhone 13 Pro의 경우 3, iPhone SE (3th gen)의 경우 2라고 합니다.
이를 정확하게 설정하지 않으면 이미지 퀄리티가 낮아보일 수 있기에 현재 화면 scale 정보에 맞도록 동적으로 변경될 수 있도록 했습니다.
     - 3 -> UIScreen.main.scale


- jpeg quality 수치를 기존 0.7 에서 1(최고 퀄리티)로 변경했습니다.
메모리 효율을 극대화하기 위해 퀄리티 수치를 0.7로 설정했었는데, 

아래 사진이 Downsampling scale 크기를 Screen scale에 맞춘 상태의 메모리 사용량이고,
![스크린샷 2023-12-08 오후 2 05 43](https://github.com/SLTDV/Choice-iOS/assets/81687906/38733018-7585-4b4f-b1ab-db62668dbf46)

아래 사진은 + 퀄리티 수치를 1로 설정했을 때 메모리 사용량입니다.
![스크린샷 2023-12-08 오후 2 06 50](https://github.com/SLTDV/Choice-iOS/assets/81687906/366f846a-15ae-428b-9a98-e01aff079d1d)

수치와같이 메모리 사용량에 큰 격차가 없어, 퀄리티를 높여 UX 적으로 불편하지 않게 하는게 좋다고 생각합니다.


ref. https://developer.apple.com/forums/thread/109445